### PR TITLE
Update language syntax to match Rust 0.11

### DIFF
--- a/Rust.JSON-tmLanguage
+++ b/Rust.JSON-tmLanguage
@@ -4,6 +4,9 @@
   "foldingStartMarker": "^.*\\bfn\\s*(\\w+\\s*)?\\([^\\)]*\\)(\\s*\\{[^\\}]*)?\\s*$",
   "foldingStopMarker": "^\\s*\\}",
   "patterns": [
+    {"include": "#rust_comment_doc_block"},
+    {"include": "#rust_ref_lifetime"},
+    {"include": "#rust_lifetime"},
     {"name": "variable.other.source.rust",
      "match": "'[a-zA-Z_][a-zA-Z0-9_]*(?=[^\\'])"
     },
@@ -21,9 +24,9 @@
       {"include": "#rust_escaped_character"}
      ]
     },
-    {"name": "string.quoted.doube.source.rust",
-     "begin": "r##\"",
-     "end": "\"##"
+    {"name": "string.quoted.double.raw.source.rust",
+     "begin": "r(#*)\"",
+     "end": "\"(\\1)"
     },
     {"name": "meta.function.source.rust",
      "match": "\\b(fn)\\s+([a-zA-Z_][a-zA-Z0-9_]?[\\w\\:,+ \\'<>]*)\\s*(?:\\()",
@@ -88,7 +91,7 @@
      "match": "([0-9][0-9_]*(f32|f64|f))|([0-9][0-9_]*([eE][+-]=[0-9_]+))|([0-9][0-9_]*([eE][+-]=[0-9_]+)(f32|f64|f))|([0-9][0-9_]*\\.[0-9_]+)|([0-9][0-9_]*\\.[0-9_]+(f32|f64|f))|([0-9][0-9_]*\\.[0-9_]+%([eE][+-]=[0-9_]+))|([0-9][0-9_]*\\.[0-9_]+%([eE][+-]=[0-9_]+)(f32|f64|f))"
     },
     {"name": "comment.line.documentation.source.rust",
-     "begin": "//!",
+     "begin": "//[!/][^/].*",
      "end": "$\\n"
     },
     {"name": "comment.line.double-dash.source.rust",
@@ -116,12 +119,50 @@
     },
     {"match": "(\\[|\\]|{|}|\\(|\\))",
      "name": "punctuation.definition.bracket.rust"
+    },
+    {
+      "match": "\\b(Box|Vec|StrBuf|Path|Option|Result|Reader|Writer|Stream|Seek|Buffer|IoError|IoResult|Sender|SyncSender|Receiver|Cell|RefCell|Any)\\b",
+      "name": "support.class.std.source.rust"
+    },
+    {
+      "match": "\\b(Send|Sized|Copy|Share)\\b",
+      "name": "support.type.kind.source.rust"
+    },
+    {
+      "match": "\\bbox\\b",
+      "name": "storage.modifier.box.source.rust"
+    },
+    {
+      "match": "\\bmut\\b",
+      "name": "storage.modifier.mut.source.rust"
     }
   ],
   "repository": {
     "rust_escaped_character": {
       "name": "constant.character.escape.source.rust",
       "match": "\\\\(x\\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)"
+    },
+    "rust_comment_doc_block": {
+      "name": "comment.block.documentation.source.rust",
+      "begin": "/\\*[!\\*][^\\*]",
+      "end": "\\*/",
+      "patterns": [
+          {"include": "#rust_comment_doc_block"}
+      ]
+    },
+    "rust_ref_lifetime": {
+      "match": "&(\\'([a-zA-Z_][a-zA-Z0-9_]*))\\b",
+      "captures": {
+        "1": { "name": "storage.modifier.lifetime.source.rust" },
+        "2": { "name": "entity.name.lifetime.source.rust" }
+      }
+    },
+    "rust_lifetime": {
+      "name": "storage.modifier.lifetime.source.rust",
+      "match": "\\'([a-zA-Z_][a-zA-Z0-9_]*)\\b",
+      "captures": {
+        "1": { "name": "entity.name.lifetime.source.rust" }
+      }
     }
   },
   "uuid": "4339386b-4d67-4f0e-9e78-09ecbcddf71d"

--- a/Rust.tmLanguage
+++ b/Rust.tmLanguage
@@ -16,6 +16,18 @@
 	<key>patterns</key>
 	<array>
 		<dict>
+			<key>include</key>
+			<string>#rust_comment_doc_block</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#rust_ref_lifetime</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#rust_lifetime</string>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>'[a-zA-Z_][a-zA-Z0-9_]*(?=[^\'])</string>
 			<key>name</key>
@@ -53,11 +65,11 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>r##"</string>
+			<string>r(#*)"</string>
 			<key>end</key>
-			<string>"##</string>
+			<string>"(\1)</string>
 			<key>name</key>
-			<string>string.quoted.doube.source.rust</string>
+			<string>string.quoted.double.raw.source.rust</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -201,7 +213,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>//!</string>
+			<string>//[!/][^/].*</string>
 			<key>end</key>
 			<string>$\n</string>
 			<key>name</key>
@@ -259,15 +271,88 @@
 			<key>name</key>
 			<string>punctuation.definition.bracket.rust</string>
 		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(Box|Vec|StrBuf|Path|Option|Result|Reader|Writer|Stream|Seek|Buffer|IoError|IoResult|Sender|SyncSender|Receiver|Cell|RefCell|Any)\b</string>
+			<key>name</key>
+			<string>support.class.std.source.rust</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(Send|Sized|Copy|Share)\b</string>
+			<key>name</key>
+			<string>support.type.kind.source.rust</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\bbox\b</string>
+			<key>name</key>
+			<string>storage.modifier.box.source.rust</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\bmut\b</string>
+			<key>name</key>
+			<string>storage.modifier.mut.source.rust</string>
+		</dict>
 	</array>
 	<key>repository</key>
 	<dict>
+		<key>rust_comment_doc_block</key>
+		<dict>
+			<key>begin</key>
+			<string>/\*[!\*][^\*]</string>
+			<key>end</key>
+			<string>\*/</string>
+			<key>name</key>
+			<string>comment.block.documentation.source.rust</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#rust_comment_doc_block</string>
+				</dict>
+			</array>
+		</dict>
 		<key>rust_escaped_character</key>
 		<dict>
 			<key>match</key>
 			<string>\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
 			<key>name</key>
 			<string>constant.character.escape.source.rust</string>
+		</dict>
+		<key>rust_lifetime</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.lifetime.source.rust</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>\'([a-zA-Z_][a-zA-Z0-9_]*)\b</string>
+			<key>name</key>
+			<string>storage.modifier.lifetime.source.rust</string>
+		</dict>
+		<key>rust_ref_lifetime</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.modifier.lifetime.source.rust</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.lifetime.source.rust</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>&amp;(\'([a-zA-Z_][a-zA-Z0-9_]*))\b</string>
 		</dict>
 	</dict>
 	<key>scopeName</key>


### PR DESCRIPTION
- Add support for rust lifetime modifiers
- Add full support for raw string
- Add support for std library containers and classes
- Add support for storage modifiers (box, mut)
- Add support for Send/Sized/...
- Add support for block documentation.
