### PR TITLE
Update language syntax to match Rust 0.11

### DIFF
--- a/Rust.JSON-tmLanguage
+++ b/Rust.JSON-tmLanguage
@@ -4,15 +4,13 @@
   "foldingStartMarker": "^.*\\bfn\\s*(\\w+\\s*)?\\([^\\)]*\\)(\\s*\\{[^\\}]*)?\\s*$",
   "foldingStopMarker": "^\\s*\\}",
   "patterns": [
-    {"name": "variable.other.source.rust",
-     "match": "'[a-zA-Z_][a-zA-Z0-9_]*(?=[^\\'])"
-    },
-    {"name": "string.quoted.single.source.rust",
-     "begin": "'",
-     "end": "'",
-     "patterns": [
-      {"include": "#rust_escaped_character"}
-      ]
+    {"include": "#rust_comment_doc_block"},
+    {"include": "#rust_ref_lifetime"},
+    {"include": "#rust_lifetime"},
+    {"include": "#rust_self"},
+    {
+      "name": "string.quoted.single.source.rust",
+      "match": "\\'([^\\'\\\\]|\\\\(x\\h{2}|[uU](\\h{4}|\\h{8})||.))\\'"
     },
     {"name": "string.quoted.double.source.rust",
      "begin": "\"",
@@ -21,9 +19,9 @@
       {"include": "#rust_escaped_character"}
      ]
     },
-    {"name": "string.quoted.doube.source.rust",
-     "begin": "r##\"",
-     "end": "\"##"
+    {"name": "string.quoted.double.raw.source.rust",
+     "begin": "r(#*)\"",
+     "end": "\"(\\1)"
     },
     {"name": "meta.function.source.rust",
      "match": "\\b(fn)\\s+([a-zA-Z_][a-zA-Z0-9_]?[\\w\\:,+ \\'<>]*)\\s*(?:\\()",
@@ -34,10 +32,11 @@
     },
     {
         "name": "meta.initialization.rust",
-        "match": "(let)\\s+([[:alpha:]_][[:alnum:]_]*)\\s*(:(.+))?\\s*(=)",
+        "match": "(let)\\s+(mut\\s+)?([[:alpha:]_][[:alnum:]_]*)\\s*(:.+)?(=)",
         "captures": {
             "1": {"name": "keyword.source.rust"},
-            "2": {"name": "variable.other.rust"},
+            "2": {"name": "keyword.source.rust"},
+            "3": {"name": "variable.other.rust"},
             "4": {"name": "storage.type.source.rust"},
             "5": {"name": "keyword.operator.rust"}
         },
@@ -88,7 +87,7 @@
      "match": "([0-9][0-9_]*(f32|f64|f))|([0-9][0-9_]*([eE][+-]=[0-9_]+))|([0-9][0-9_]*([eE][+-]=[0-9_]+)(f32|f64|f))|([0-9][0-9_]*\\.[0-9_]+)|([0-9][0-9_]*\\.[0-9_]+(f32|f64|f))|([0-9][0-9_]*\\.[0-9_]+%([eE][+-]=[0-9_]+))|([0-9][0-9_]*\\.[0-9_]+%([eE][+-]=[0-9_]+)(f32|f64|f))"
     },
     {"name": "comment.line.documentation.source.rust",
-     "begin": "//!",
+     "begin": "//[!/][^/].*",
      "end": "$\\n"
     },
     {"name": "comment.line.double-dash.source.rust",
@@ -111,17 +110,63 @@
     {"name": "meta.namespace-block.rust",
      "match": "\\b(\\w+)::"
     },
-    {"name": "meta.preprocessor.rust",
-     "match": "\\b(\\w+)!"
+    {
+      "name": "meta.macro.source.rust",
+      "match": "\\b(\\w+!)\\s*[({\\[]",
+      "captures": {
+        "1": { "name": "meta.preprocessor.rust" }
+      }
     },
     {"match": "(\\[|\\]|{|}|\\(|\\))",
      "name": "punctuation.definition.bracket.rust"
+    },
+    {
+      "match": "\\b(Box|Vec|StrBuf|Path|Option|Result|Reader|Writer|Stream|Seek|Buffer|IoError|IoResult|Sender|SyncSender|Receiver|Cell|RefCell|Any)\\b",
+      "name": "support.class.std.source.rust"
+    },
+    {
+      "match": "\\b(Send|Sized|Copy|Share)\\b",
+      "name": "support.type.kind.source.rust"
+    },
+    {
+      "match": "\\bbox\\b",
+      "name": "storage.modifier.box.source.rust"
+    },
+    {
+      "match": "\\bmut\\b",
+      "name": "storage.modifier.mut.source.rust"
     }
   ],
   "repository": {
     "rust_escaped_character": {
       "name": "constant.character.escape.source.rust",
       "match": "\\\\(x\\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)"
+    },
+    "rust_comment_doc_block": {
+      "name": "comment.block.documentation.source.rust",
+      "begin": "/\\*[!\\*][^\\*]",
+      "end": "\\*/",
+      "patterns": [
+          {"include": "#rust_comment_doc_block"}
+      ]
+    },
+    "rust_ref_lifetime": {
+      "match": "&(\\'([a-zA-Z_][a-zA-Z0-9_]*))\\b",
+      "captures": {
+        "1": { "name": "storage.modifier.lifetime.source.rust" },
+        "2": { "name": "entity.name.lifetime.source.rust" }
+      }
+    },
+    "rust_lifetime": {
+      "name": "storage.modifier.lifetime.source.rust",
+      "match": "\\'([a-zA-Z_][a-zA-Z0-9_]*)[^\\']\\b",
+      "captures": {
+        "1": { "name": "entity.name.lifetime.source.rust" }
+      }
+    },
+    "rust_self": {
+      "name": "variable.language.source.rust",
+      "match": "\\bself\\b"
     }
   },
   "uuid": "4339386b-4d67-4f0e-9e78-09ecbcddf71d"

--- a/Rust.tmLanguage
+++ b/Rust.tmLanguage
@@ -16,25 +16,26 @@
 	<key>patterns</key>
 	<array>
 		<dict>
-			<key>match</key>
-			<string>'[a-zA-Z_][a-zA-Z0-9_]*(?=[^\'])</string>
-			<key>name</key>
-			<string>variable.other.source.rust</string>
+			<key>include</key>
+			<string>#rust_comment_doc_block</string>
 		</dict>
 		<dict>
-			<key>begin</key>
-			<string>'</string>
-			<key>end</key>
-			<string>'</string>
+			<key>include</key>
+			<string>#rust_ref_lifetime</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#rust_lifetime</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#rust_self</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\'([^\'\\]|\\(x\h{2}|[uU](\h{4}|\h{8})||.))\'</string>
 			<key>name</key>
 			<string>string.quoted.single.source.rust</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#rust_escaped_character</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -53,11 +54,11 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>r##"</string>
+			<string>r(#*)"</string>
 			<key>end</key>
-			<string>"##</string>
+			<string>"(\1)</string>
 			<key>name</key>
-			<string>string.quoted.doube.source.rust</string>
+			<string>string.quoted.double.raw.source.rust</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -89,6 +90,11 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
+					<string>keyword.source.rust</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
 					<string>variable.other.rust</string>
 				</dict>
 				<key>4</key>
@@ -105,7 +111,7 @@
 			<key>comment</key>
 			<string>This matches the 'let x = val' style of variable intitialization.</string>
 			<key>match</key>
-			<string>(let)\s+([[:alpha:]_][[:alnum:]_]*)\s*(:(.+))?\s*(=)</string>
+			<string>(let)\s+(mut\s+)?([[:alpha:]_][[:alnum:]_]*)\s*(:.+)?(=)</string>
 			<key>name</key>
 			<string>meta.initialization.rust</string>
 		</dict>
@@ -201,7 +207,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>//!</string>
+			<string>//[!/][^/].*</string>
 			<key>end</key>
 			<string>$\n</string>
 			<key>name</key>
@@ -248,10 +254,18 @@
 			<string>meta.namespace-block.rust</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>meta.preprocessor.rust</string>
+				</dict>
+			</dict>
 			<key>match</key>
-			<string>\b(\w+)!</string>
+			<string>\b(\w+!)\s*[({\[]</string>
 			<key>name</key>
-			<string>meta.preprocessor.rust</string>
+			<string>meta.macro.source.rust</string>
 		</dict>
 		<dict>
 			<key>match</key>
@@ -259,15 +273,95 @@
 			<key>name</key>
 			<string>punctuation.definition.bracket.rust</string>
 		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(Box|Vec|StrBuf|Path|Option|Result|Reader|Writer|Stream|Seek|Buffer|IoError|IoResult|Sender|SyncSender|Receiver|Cell|RefCell|Any)\b</string>
+			<key>name</key>
+			<string>support.class.std.source.rust</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(Send|Sized|Copy|Share)\b</string>
+			<key>name</key>
+			<string>support.type.kind.source.rust</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\bbox\b</string>
+			<key>name</key>
+			<string>storage.modifier.box.source.rust</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\bmut\b</string>
+			<key>name</key>
+			<string>storage.modifier.mut.source.rust</string>
+		</dict>
 	</array>
 	<key>repository</key>
 	<dict>
+		<key>rust_comment_doc_block</key>
+		<dict>
+			<key>begin</key>
+			<string>/\*[!\*][^\*]</string>
+			<key>end</key>
+			<string>\*/</string>
+			<key>name</key>
+			<string>comment.block.documentation.source.rust</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#rust_comment_doc_block</string>
+				</dict>
+			</array>
+		</dict>
 		<key>rust_escaped_character</key>
 		<dict>
 			<key>match</key>
 			<string>\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
 			<key>name</key>
 			<string>constant.character.escape.source.rust</string>
+		</dict>
+		<key>rust_lifetime</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.lifetime.source.rust</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>\'([a-zA-Z_][a-zA-Z0-9_]*)[^\']\b</string>
+			<key>name</key>
+			<string>storage.modifier.lifetime.source.rust</string>
+		</dict>
+		<key>rust_ref_lifetime</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.modifier.lifetime.source.rust</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.lifetime.source.rust</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>&amp;(\'([a-zA-Z_][a-zA-Z0-9_]*))\b</string>
+		</dict>
+		<key>rust_self</key>
+		<dict>
+			<key>match</key>
+			<string>\bself\b</string>
+			<key>name</key>
+			<string>variable.language.source.rust</string>
 		</dict>
 	</dict>
 	<key>scopeName</key>


### PR DESCRIPTION
- Add support for rust lifetime modifiers
- Add full support for raw string
- Add support for std library containers and classes
- Add support for storage modifiers (box, mut)
- Add support for Send/Sized/...
- Add support for block documentation.
