### PR TITLE
Updates syntax highlighting

### DIFF
--- a/Rust.JSON-tmLanguage
+++ b/Rust.JSON-tmLanguage
@@ -66,7 +66,7 @@
      "match": "\\b(EXIT_FAILURE|EXIT_SUCCESS|RAND_MAX|EOF|SEEK_SET|SEEK_CUR|SEEK_END|_IOFBF|_IONBF|_IOLBF|BUFSIZ|FOPEN_MAX|FILENAME_MAX|L_tmpnam|TMP_MAX|O_RDONLY|O_WRONLY|O_RDWR|O_APPEND|O_CREAT|O_EXCL|O_TRUNC|S_IFIFO|S_IFCHR|S_IFBLK|S_IFDIR|S_IFREG|S_IFMT|S_IEXEC|S_IWRITE|S_IREAD|S_IRWXU|S_IXUSR|S_IWUSR|S_IRUSR|F_OK|R_OK|W_OK|X_OK|STDIN_FILENO|STDOUT_FILENO|STDERR_FILENO)\\b"
     },
     {"name": "comment.block.attribute.rust",
-     "begin": "#\\[",
+     "begin": "#!?\\[",
      "end": "\\]",
      "patterns": [
         {  "name": "string.quoted.double",
@@ -102,7 +102,7 @@
      "match": "(=>)|(->)|[-:=*,!.+|%/&~@<>;]"
     },
     {"name": "support.function.rust",
-     "match": "_"
+     "match": "\\b_\\b"
     },
     {"name": "support.function.rust",
      "match": "\\b(\\w+)\\b(?=\\()"

--- a/Rust.tmLanguage
+++ b/Rust.tmLanguage
@@ -166,7 +166,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>#\[</string>
+			<string>#!?\[</string>
 			<key>end</key>
 			<string>\]</string>
 			<key>name</key>
@@ -237,7 +237,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>_</string>
+			<string>\b_\b</string>
 			<key>name</key>
 			<string>support.function.rust</string>
 		</dict>


### PR DESCRIPTION
Underscore is not colored if embedded in another word

Crate-level attributes ( #![...] ) colored identically to normal
attributes.
