### PR TITLE
Fix toggle on-save checking command.

### DIFF
--- a/toggle_setting.py
+++ b/toggle_setting.py
@@ -1,9 +1,19 @@
-import sublime, sublime_plugin
+import sublime_plugin
+from .rust import (util, messages)
+
 
 class ToggleRustSyntaxSettingCommand(sublime_plugin.TextCommand):
 
-    def run(self, setting):
-        # Grab the setting and reserse it
-        current_state = self.view.settings().get('rust_syntax_checking')
-        self.view.settings().set('rust_syntax_checking', not current_state)
-        self.view.window().status_message("Rust syntax checking is now " + ("inactive" if current_state else "active"))
+    """Toggles on-save checking for the current window."""
+
+    def run(self, edit):
+        # Grab the setting and reverse it.
+        window = self.view.window()
+        current_state = util.get_setting('rust_syntax_checking', True)
+        new_state = not current_state
+        pdata = window.project_data()
+        pdata.setdefault('settings', {})['rust_syntax_checking'] = new_state
+        if not new_state:
+            messages.clear_messages(window)
+        window.status_message("Rust syntax checking is now " + ("inactive" if current_state else "active"))
+        window.set_project_data(pdata)


### PR DESCRIPTION
This also changes the command to change the setting for the entire window instead of the current view.  I'm uncertain if that is actually desired.  What do others think?  It's not too hard to leave it per-view, or that could be an option.
