### PR TITLE
replace after-operator with check for type declaration syntax

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -71,6 +71,12 @@ contexts:
         1: storage.modifier.rust
         2: storage.type.type.rust
         3: entity.name.type.rust
+      push:
+      - match: '=(?!=)'
+        scope: keyword.operator.rust
+        push: after-operator
+      - match: '(?=\S)'
+        pop: true
 
     - match: '\b(?:(pub)\s+)?(trait)\s+({{identifier}})\b'
       captures:
@@ -129,7 +135,6 @@ contexts:
 
     - match: \breturn\b
       scope: keyword.control.rust
-      push: after-operator
 
     - match: \b(as|in|box)\b
       scope: keyword.operator.rust
@@ -213,18 +218,14 @@ contexts:
     # match blocks containing just enums
     - match: '=>'
       scope: keyword.operator.rust
-      push: after-operator
 
     - match: '=(?!=)'
       scope: keyword.operator.rust
-      push: after-operator
 
     - match: '[;,]'
-      push: after-operator
 
     - match: ':'
       scope: punctuation.separator.rust
-      push: after-operator
 
     - match: '\.\.\.'
       scope: keyword.operator.rust

--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -446,6 +446,7 @@ contexts:
       pop: true
 
   type-any-identifier:
+    - include: comments
     - include: support-type
     - include: return-type
     - match: '&'

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -1105,3 +1105,31 @@ fn foo<F: FnMut(i32, i32 /*asd*/) -> i32>(f: F) {
 //                       ^^^^^^^^^^^^^ meta.function.parameters comment
     };
 }
+
+// mdo example
+fn main() {
+    // exporting the monadic functions for the Iterator monad (similar
+    // to list comprehension)
+    use mdo::iter::{bind, ret, mzero};
+
+    let l = bind(1i32..11, move |z|
+                 bind(1..z, move |x|
+                      bind(x..z, move |y|
+                           bind(if x * x + y * y == z * z { ret(()) }
+                                else { mzero() },
+                                move |_|
+                                ret((x, y, z))
+                                )))).collect::<Vec<_>>();
+    println!("{:?}", l);
+
+    // the same thing, using the mdo! macro
+    let l = mdo! {
+        z =<< 1i32..11;
+        x =<< 1..z;
+//        ^^^ keyword.operator
+        y =<< x..z;
+        when x * x + y * y == z * z;
+        ret ret((x, y, z))
+    }.collect::<Vec<_>>();
+    println!("{:?}", l);
+}

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -1098,3 +1098,10 @@ where
 //^^^^^^^^^^^^^^^ meta.struct
 //           ^^^ meta.struct meta.where storage.type
 //               ^ punctuation.terminator
+
+fn foo<F: FnMut(i32, i32 /*asd*/) -> i32>(f: F) {
+//                       ^^^^^^^ meta.generic comment
+    let lam = |time: i32 /* comment */, other: i32| {
+//                       ^^^^^^^^^^^^^ meta.function.parameters comment
+    };
+}


### PR DESCRIPTION
the after-operator was to deal with type declarations of the style used in `forward_ref_binop` which contains `type Output = <$t as $imp<$u>>::Output;`

there is a more precise way to deal with this and it fixes other macro syntax highlighting such as in mdo (although it uses a custom operator so all bets are off)


fixes #219 a 
![image](https://user-images.githubusercontent.com/1019038/32081517-dd0b0ff2-baad-11e7-9ca1-9e8d3efec3d9.png)
