### PR TITLE
Update messages for changes in 1.21, 1.22, 1.23 (beta), and 1.24 (nightly)

### DIFF
--- a/rust/messages.py
+++ b/rust/messages.py
@@ -9,7 +9,6 @@ import itertools
 import os
 import re
 import webbrowser
-from pprint import pprint
 
 from . import util
 
@@ -720,16 +719,21 @@ def add_rust_messages(window, cwd, info, target_path, msg_cb):
                 # end of the message, which we don't want.
                 return html.escape(txt.strip(), quote=False).\
                     replace('\n', '<br>' + indent)
-        parts = re.split(LINK_PATTERN, message['text'])
-        escaped_text = ''.join(map(escape_and_link, enumerate(parts)))
 
-        content = content_template.format(
-            cls=cls,
-            level=level_text,
-            msg=escaped_text,
-            help_link=message.get('help_link', ''),
-            back_link=message.get('back_link', ''),
-        )
+        if message['text']:
+            parts = re.split(LINK_PATTERN, message['text'])
+            escaped_text = ''.join(map(escape_and_link, enumerate(parts)))
+
+            content = content_template.format(
+                cls=cls,
+                level=level_text,
+                msg=escaped_text,
+                help_link=message.get('help_link', ''),
+                back_link=message.get('back_link', ''),
+            )
+        else:
+            content = None
+
         add_message(window, message['span_path'], message['span_region'],
                     level, message['is_main'], message['text'], content,
                     msg_cb)
@@ -963,7 +967,10 @@ def _collect_rust_messages(window, cwd, info, target_path,
         # to happen when the span is_primary.
         #
         # This can also happen for macro expansions.
-        if label:
+        #
+        # Label with an empty string can happen for messages that have
+        # multiple spans (starting in 1.21).
+        if label != None:
             # Display the label for this Span.
             add_additional(span, label, info['level'])
         if span['suggested_replacement']:

--- a/rust/messages.py
+++ b/rust/messages.py
@@ -148,7 +148,7 @@ def add_message(window, path, span, level, is_main, text, minihtml_text, msg_cb)
 
 
 def _is_duplicate(to_add, messages):
-    # Ignore 'phantom_text' and 'output_panel_region' keys.
+    # Ignore 'minihtml_text' and 'output_panel_region' keys.
     keys = ('path', 'span', 'is_main', 'level', 'text')
     for message in messages:
         for key in keys:

--- a/tests/error-tests/benches/bench_err.rs
+++ b/tests/error-tests/benches/bench_err.rs
@@ -3,5 +3,5 @@
 
    #[asdf]
 // ^^^^^^^ERR The attribute `asdf` is currently unknown
-// ^^^^^^^HELP(>=1.21.0-nightly) add #![feature(custom_attribute)]
+// ^^^^^^^HELP(nightly) add #![feature(custom_attribute)]
 fn f() {}

--- a/tests/error-tests/examples/no_main_mod.rs
+++ b/tests/error-tests/examples/no_main_mod.rs
@@ -1,5 +1,7 @@
 /*BEGIN*/fn main() {
+//       ^^^^^^^^^WARN(no-trans) function is never used
+//       ^^^^^^^^^NOTE(no-trans) #[warn(dead_code)]
+// 1.24 nightly has changed how these no-trans messages are displayed (instead
+// of encompassing the entire function).
 }/*END*/
 // ~NOTE(check) here is a function named 'main'
-// ~NOTE(no-trans) function is never used
-// ~NOTE(no-trans) #[warn(dead_code)]

--- a/tests/error-tests/tests/cast-to-unsized-trait-object-suggestion.rs
+++ b/tests/error-tests/tests/cast-to-unsized-trait-object-suggestion.rs
@@ -12,9 +12,9 @@ fn main() {
     &1 as Send;
 //  ^^^^^^^^^^ERR cast to unsized type
 //        ^^^^HELP try casting to
-//        ^^^^HELP &1 as &Send
+//        ^^^^HELP &Send
     Box::new(1) as Send;
 //  ^^^^^^^^^^^^^^^^^^^ERR cast to unsized type
 //                 ^^^^HELP try casting to a `Box` instead
-//                 ^^^^HELP Box::new(1) as Box<Send>;
+//                 ^^^^HELP Box<Send>
 }

--- a/tests/error-tests/tests/macro-backtrace-println.rs
+++ b/tests/error-tests/tests/macro-backtrace-println.rs
@@ -22,7 +22,9 @@ macro_rules! myprint {
 
 macro_rules! myprintln {
     ($fmt:expr) => (myprint!(concat!($fmt, "\n")));
-//                           ^^^^^^^^^^^^^^^^^^^ERR invalid reference
+//                           ^^^^^^^^^^^^^^^^^^^ERR(<1.23.0-beta) invalid reference
+//                           ^^^^^^^^^^^^^^^^^^^ERR(>=1.23.0-beta) 1 positional argument
+//                           ^^^^^^^^^^^^^^^^^^^MSG Note: ↓:31
 }
 
 fn main() {

--- a/tests/error-tests/tests/macro-expansion-outside-1.rs
+++ b/tests/error-tests/tests/macro-expansion-outside-1.rs
@@ -7,12 +7,12 @@ extern crate dcrate;
 // at the bottom of the "root" source file.
 
 /*BEGIN*/example_bad_syntax!{}/*END*/
-// ~ERR(>=1.20.0-beta) /expected one of .*, found `:`/
-// ~ERR(>=1.20.0-beta) this error originates in a macro outside of the current crate
-// ~ERR(>=1.20.0-beta) /expected one of .* here/
-// ~ERR(>=1.20.0-beta) unexpected token
-// ~ERR(>=1.20.0-beta) /expected one of .*, found `:`/
-// ~ERR(>=1.20.0-beta) expected one of 7 possible tokens here
+// ~ERR(>=1.20.0) /expected one of .*, found `:`/
+// ~ERR(>=1.20.0) this error originates in a macro outside of the current crate
+// ~ERR(>=1.20.0) /expected one of .* here/
+// ~ERR(>=1.20.0,<1.24.0-nightly) unexpected token
+// ~ERR(>=1.20.0) /expected one of .*, found `:`/
+// ~ERR(>=1.20.0) expected one of
 // end-msg: ERR(check,>=1.19.0,<1.20.0-beta) /expected one of .*, found `:`/
 // end-msg: ERR(check,>=1.19.0,<1.20.0-beta) Errors occurred in macro <example_bad_syntax macros> from external crate
 // end-msg: ERR(check,>=1.19.0,<1.20.0-beta) Macro text: (  ) => { enum E { Kind ( x : u32 ) } }

--- a/tests/error-tests/tests/macro_expansion_inside_mod1.rs
+++ b/tests/error-tests/tests/macro_expansion_inside_mod1.rs
@@ -5,9 +5,9 @@ macro_rules! example_bad_syntax {
             Kind(x: u32)
 //                ^ERR /expected one of .*, found `:`/
 //                ^ERR(>=1.18.0) /expected one of .* here/
-//                ^MSG(>=1.20.0-beta) Note: macro-expansion-inside-1.rs:6
+//                ^MSG(>=1.20.0) Note: macro-expansion-inside-1.rs:6
 //                ^ERR /expected one of .*, found `:`/
-//                ^ERR(>=1.18.0) expected one of 7 possible tokens here
+//                ^ERR(>=1.18.0) expected one of
         }
     }
 }

--- a/tests/error-tests/tests/test_new_lifetime_message.rs
+++ b/tests/error-tests/tests/test_new_lifetime_message.rs
@@ -1,0 +1,11 @@
+// 1.21 added new support for messages with multiple spans.
+/*BEGIN*/fn foo(x: &mut Vec<&u32>, y: &u32) {
+//                          ^^^^ERR(>=1.21.0)
+//                                    ^^^^ERR(>=1.21.0) these two types
+  x.push(y);
+//       ^ERR(>=1.21.0) lifetime mismatch
+//       ^ERR(>=1.21.0) ...but data from
+//       ^ERR(<1.21.0) lifetime of reference outlives
+}/*END*/
+// ~NOTE(<1.21.0) ...the reference is valid
+// ~NOTE(<1.21.0) ...but the borrowed content

--- a/tests/error-tests/tests/test_unicode.rs
+++ b/tests/error-tests/tests/test_unicode.rs
@@ -4,5 +4,6 @@ fn main() {
     let foo = "❤";
 //      ^^^WARN unused variable
 //      ^^^NOTE(>=1.17.0) #[warn(unused_variables)]
-//      ^^^NOTE(>=1.22.0-nightly) to disable this warning
+//      ^^^NOTE(>=1.21.0,<1.22.0) to disable this warning
+//      ^^^NOTE(>=1.22.0) to avoid this warning
 }

--- a/tests/multi-targets/src/altmain.rs
+++ b/tests/multi-targets/src/altmain.rs
@@ -3,6 +3,8 @@ fn main() {
 }
 
 /*BEGIN*/fn warning_example() {
+//       ^^^^^^^^^^^^^^^^^^^^WARN(>=1.22.0) function is never used
+//       ^^^^^^^^^^^^^^^^^^^^NOTE(>=1.22.0) #[warn(dead_code)]
 }/*END*/
-// ~WARN function is never used
-// ~NOTE(>=1.17.0) #[warn(dead_code)]
+// ~WARN(<1.22.0) function is never used
+// ~NOTE(<1.22.0,>=1.17.0) #[warn(dead_code)]

--- a/tests/multi-targets/src/lib.rs
+++ b/tests/multi-targets/src/lib.rs
@@ -5,6 +5,8 @@ pub fn libf1() {
 }
 
 /*BEGIN*/fn unused() {
+//       ^^^^^^^^^^^WARN(>=1.22.0) function is never used
+//       ^^^^^^^^^^^NOTE(>=1.22.0) #[warn(dead_code)]
 }/*END*/
-// ~WARN function is never used
-// ~NOTE(>=1.17.0) #[warn(dead_code)]
+// ~WARN(<1.22.0) function is never used
+// ~NOTE(<1.22.0,>=1.17.0) #[warn(dead_code)]

--- a/tests/multi-targets/tests/common/helpers.rs
+++ b/tests/multi-targets/tests/common/helpers.rs
@@ -1,13 +1,15 @@
 // Example of a module shared among test code.
 
 /*BEGIN*/pub fn helper() {
-
+//       ^^^^^^^^^^^^^^^WARN(>=1.22.0) function is never used
+//       ^^^^^^^^^^^^^^^NOTE(>=1.22.0) #[warn(dead_code)]
 }/*END*/
-// ~WARN function is never used
-// ~NOTE(>=1.17.0) #[warn(dead_code)]
+// ~WARN(<1.22.0) function is never used
+// ~NOTE(<1.22.0,>=1.17.0) #[warn(dead_code)]
 
 /*BEGIN*/pub fn unused() {
-
+//       ^^^^^^^^^^^^^^^WARN(>=1.22.0) function is never used
+//       ^^^^^^^^^^^^^^^NOTE(<1.24.0-nightly) #[warn(dead_code)]
 }/*END*/
-// ~WARN function is never used
-// ~NOTE(>=1.17.0) #[warn(dead_code)]
+// ~WARN(<1.22.0) function is never used
+// ~NOTE(<1.22.0,>=1.17.0) #[warn(dead_code)]

--- a/tests/test_syntax_check.py
+++ b/tests/test_syntax_check.py
@@ -223,6 +223,9 @@ class TestSyntaxCheck(TestBase):
                     # This message only shows up in no-trans.
                     if method != 'no-trans':
                         return False
+                elif check == 'nightly':
+                    # This message only shows on nightly.
+                    return 'nightly' in self.rustc_version
                 else:
                     if not semver.match(self.rustc_version, check):
                         return False
@@ -254,8 +257,8 @@ class TestSyntaxCheck(TestBase):
                         view.file_name(), method, phantoms))
                 del phantoms[i]
         if len(phantoms):
-            raise AssertionError('Got extra phantoms for %r (method=%s): %r' % (
-                view.file_name(), method, phantoms))
+            raise AssertionError('Got extra phantoms for %r (method=%s, version=%s): %r' % (
+                view.file_name(), method, self.rustc_version, phantoms))
 
         # Check regions.
         found_regions = set()

--- a/tests/test_syntax_check.py
+++ b/tests/test_syntax_check.py
@@ -104,6 +104,7 @@ class TestSyntaxCheck(TestBase):
             ('error-tests/tests/macro-expansion-inside-2.rs', 'error-tests/tests/macro_expansion_inside_mod2.rs'),
             ('error-tests/tests/error_across_mod.rs', 'error-tests/tests/error_across_mod_f.rs'),
             'error-tests/tests/derive-error.rs',
+            'error-tests/tests/test_new_lifetime_message.rs',
             # Workspace tests.
             'workspace/workspace1/src/lib.rs',
             'workspace/workspace1/src/anothermod/mod.rs',
@@ -235,6 +236,9 @@ class TestSyntaxCheck(TestBase):
 
         # Check phantoms.
         for emsg_info in expected_messages:
+            if not emsg_info['message']:
+                # This is a region-only highlight.
+                continue
             if restriction_check(emsg_info['restrictions']):
                 for i, (region, content) in enumerate(phantoms):
                     content = unescape(content)
@@ -331,7 +335,7 @@ class TestSyntaxCheck(TestBase):
         # Single-line spans.
         last_line = None
         last_line_offset = 1
-        pattern = r'//( *)(\^+)(WARN|ERR|HELP|NOTE|MSG)(\([^)]+\))? (.+)'
+        pattern = r'//( *)(\^+)(WARN|ERR|HELP|NOTE|MSG)(\([^)]+\))?(?: (.+))?'
         regions = view.find_all(pattern)
         for region in regions:
             text = view.substr(region)

--- a/tests/workspace/workspace2/src/lib.rs
+++ b/tests/workspace/workspace2/src/lib.rs
@@ -9,5 +9,7 @@ pub fn f() {
 //                  ^ERR mismatched types
 //                  ^NOTE expected type `&Trait`
 //                  ^NOTE(<1.16.0) found type
-//                  ^HELP(>=1.18.0) try with `&x`
+//                  ^HELP(>=1.18.0,<1.24.0-nightly) try with `&x`
+//                  ^HELP(>=1.24.0-nightly) consider borrowing here
+//                  ^HELP(>=1.24.0-nightly) &x
 }


### PR DESCRIPTION
- Support new suggestion JSON format introduced in 1.23/1.24.
- Fix some duplicate messages being displayed.
- Update tests for minor wording changes in some diagnostics.
- Update tests to handle debug files being produced in 1.21.
- Support multi-span messages added in 1.21.

Fixes #227.