### PR TITLE
a few small syntax checking improvements

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -395,7 +395,7 @@ contexts:
   type:
     - match: '{{identifier}}(?=<)'
       push: generic-angles
-    - match: \b(Self|i8|i16|i32|i64|isize|u8|u16|u32|u64|usize|f32|f64|bool|char|str)\b
+    - match: \b(Self|{{int_suffixes}}|{{float_suffixes}}|bool|char|str)\b
       scope: storage.type.rust
 
   generic-angles:

--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -7,9 +7,10 @@ file_extensions:
 scope: source.rust
 variables:
   identifier: '(?:[[:alpha:]][_[:alnum:]]*|_[_[:alnum:]]+)'
-  escaped_byte: '\\(x\h{2}|n|r|t|0|"|''|\\)'
-  escaped_char: '\\(x\h{2}|n|r|t|0|"|''|\\|u\{\h{1,6}\})'
+  escaped_byte: '\\([nrt0\"''\\]|x\h{2})'
+  escaped_char: '\\([nrt0\"''\\]|x\h{2}|u\{\h{1,6}\})'
   int_suffixes: '[iu](?:8|16|32|64|size)'
+  float_suffixes: 'f(32|64)'
 contexts:
   main:
     - include: statements
@@ -310,8 +311,8 @@ contexts:
       scope: keyword.operator.rust
     - match: '[!]?(?=\bSync|Send\b)'
       scope: keyword.operator.rust
-    - match: \b(Copy|Send|Sized|Sync|Drop|Fn|FnMut|FnOnce|Box|ToOwned|Clone|PartialEq|PartialOrd|Eq|Ord|AsRef|AsMut|Into|From|Default|Iterator|Extend|IntoIterator|DoubleEndedIterator|ExactSizeIterator|Option|Some|None|Result|Ok|Err|SliceConcatExt|String|ToString|Vec)\b 
-      scope: support.type.rust 
+    - match: \b(Copy|Send|Sized|Sync|Drop|Fn|FnMut|FnOnce|Box|ToOwned|Clone|PartialEq|PartialOrd|Eq|Ord|AsRef|AsMut|Into|From|Default|Iterator|Extend|IntoIterator|DoubleEndedIterator|ExactSizeIterator|Option|Some|None|Result|Ok|Err|SliceConcatExt|String|ToString|Vec)\b
+      scope: support.type.rust
 
   return-type:
     - match: '\bimpl\b'
@@ -982,14 +983,18 @@ contexts:
       scope: constant.other.placeholder.rust
 
   numbers:
-    - match: '\b((?:\d[\d_]*)?\d\.)(\d[\d_]*(?:[eE][+-]?[\d_]*\d[\d_]*)?)(f32|f64)?'
+    - match: '\b((?:\d[\d_]*)?\.)(\d[\d_]*(?:[eE][+-]?[\d_]+)?)({{float_suffixes}})?'
       captures:
         1: constant.numeric.float.rust
         2: constant.numeric.float.rust
         3: storage.type.numeric.rust
-    - match: '\b((?:\d[\d_]*)?\d\.)(?!\.)'
+    - match: '\b(\d[\d_]*\.)(?!\.)'
       scope: constant.numeric.float.rust
-    - match: '\b(\d[\d_]*)(f32|f64)\b'
+    - match: '\b(\d[\d_]*)({{float_suffixes}})\b'
+      captures:
+        1: constant.numeric.float.rust
+        2: storage.type.numeric.rust
+    - match: '\b(\d[\d_]*(?:\.[\d_]+)?[eE][-+]?[\d_]+)({{float_suffixes}})?\b'
       captures:
         1: constant.numeric.float.rust
         2: storage.type.numeric.rust
@@ -997,15 +1002,15 @@ contexts:
       captures:
         1: constant.numeric.integer.decimal.rust
         2: storage.type.numeric.rust
-    - match: '\b(0x[\h_]*\h[\h_]*)({{int_suffixes}})?\b'
+    - match: '\b(0x[\h_]+)({{int_suffixes}})?\b'
       captures:
         1: constant.numeric.integer.hexadecimal.rust
         2: storage.type.numeric.rust
-    - match: '\b(0o[0-7_]*[0-7][0-7_]*)({{int_suffixes}})?\b'
+    - match: '\b(0o[0-7_]+)({{int_suffixes}})?\b'
       captures:
         1: constant.numeric.integer.octal.rust
         2: storage.type.numeric.rust
-    - match: '\b(0b[0-1_]*[0-1][0-1_]*)({{int_suffixes}})?\b'
+    - match: '\b(0b[0-1_]+)({{int_suffixes}})?\b'
       captures:
         1: constant.numeric.integer.binary.rust
         2: storage.type.numeric.rust

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -98,6 +98,15 @@ let raw_bytes = br#"This won't escape anything either \x01 \""#;
 // <- constant.numeric.float
  // <- storage.type - constant.numeric.float
 //^^ storage.type - constant.numeric.float
+1e+8;
+// <- constant.numeric.float
+ // <- constant.numeric.float
+//^^ constant.numeric.float
+1.0E-8234987_f64;
+// <- constant.numeric.float
+ // <- constant.numeric.float
+//^^^^^^^^^^^ constant.numeric.float
+//           ^^^ storage.type - constant.numeric.float
 
 0x0;
 // <- constant.numeric.integer.hexadecimal


### PR DESCRIPTION
The only really important bit of this is `\b(\d[\d_]*(?:\.[\d_]+)?[eE][-+]?[\d_]+)({{float_suffixes}})?\b` which now matches literals like `1e8`.  There's probably a simpler way of solving it but I couldn't find it.

The other changes are just small performance improvements I noticed.

All the syntax checks passed: `Success: 3554 assertions in 1 files passed`.