### PR TITLE
Add Travis and AppVeyor.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+env:
+    global:
+        - PACKAGE="Rust Enhanced"
+        - SUBLIME_TEXT_VERSION="3"
+
+language: rust
+
+matrix:
+    include:
+        - os: linux
+          rust: stable
+
+        - os: osx
+          rust: stable
+
+        - os: linux
+          rust: beta
+
+        - os: osx
+          rust: beta
+
+        - os: linux
+          rust: nightly
+
+        - os: osx
+          rust: nightly
+
+
+before_install:
+    - curl -OL https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/travis.sh
+
+    # enable gui, see https://docs.travis-ci.com/user/gui-and-headless-browsers
+    - if [ "$TRAVIS_OS_NAME" == "linux"  ]; then
+            export DISPLAY=:99.0;
+            sh -e /etc/init.d/xvfb start;
+      fi
+
+
+install:
+    # Install Sublime and Sublime Unittesting.
+    - sh travis.sh bootstrap
+    # Install Package Control, needed for dependencies.
+    - sh travis.sh install_package_control
+
+    # Ensure nightly is installed to run no-trans, benchmarks, and Clippy.
+    - rustup install nightly
+    # Install Rust packages needed by integration tests.
+    - cargo +nightly install clippy || export RE_SKIP_CLIPPY=1
+    - cargo install cargo-script
+
+
+script:
+    - sh travis.sh run_syntax_tests
+    - sh travis.sh run_tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+environment:
+    global:
+        PACKAGE: "Rust Enhanced"
+        SUBLIME_TEXT_VERSION : "3"
+
+    matrix:
+        - RUST_VERSION: stable
+        - RUST_VERSION: beta
+        - RUST_VERSION: nightly
+
+
+install:
+    - ps: appveyor DownloadFile "https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/appveyor.ps1"
+    # Install Sublime and Sublime Unittesting.
+    - ps: .\appveyor.ps1 "bootstrap" -verbose
+    - ps: .\appveyor.ps1 "install_package_control" -verbose
+    # Install rust.
+    - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+    - rustup-init.exe -y --default-toolchain %RUST_VERSION%
+    - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+    # Ensure nightly is installed to run no-trans, benchmarks, and Clippy.
+    - rustup install nightly
+    # Install Rust packages needed by integration tests.
+    - cargo +nightly install clippy || set RE_SKIP_CLIPPY=1
+    - cargo install cargo-script
+    - rustc -Vv
+
+build: off
+
+test_script:
+    - ps: .\appveyor.ps1 "run_syntax_tests" -verbose
+    - ps: .\appveyor.ps1 "run_tests" -verbose

--- a/cargo_build.py
+++ b/cargo_build.py
@@ -423,9 +423,7 @@ class CargoCurrentFile(sublime_plugin.WindowCommand):
     what = None
 
     def run(self):
-        print('current file')
         def _test_file(target):
-            print('target is %r' % target)
             self.window.run_command('cargo_exec', args={
                 'command': self.what,
                 'settings': {

--- a/rust/cargo_settings.py
+++ b/rust/cargo_settings.py
@@ -125,6 +125,15 @@ CARGO_COMMANDS = {
 }
 
 
+CARGO_BUILD_DEFAULTS = {
+    'variants': {
+        'clippy': {
+            'toolchain': 'nightly',
+        }
+    }
+}
+
+
 class CargoSettings(object):
 
     """Interface to Cargo project settings stored in `sublime-project`
@@ -146,9 +155,11 @@ class CargoSettings(object):
         self.re_settings = sublime.load_settings('RustEnhanced.sublime-settings')
 
     def get_global_default(self, key, default=None):
+        internal_default = CARGO_BUILD_DEFAULTS.get('defaults', {})\
+                                               .get(key, default)
         return self.re_settings.get('cargo_build', {})\
                                .get('defaults', {})\
-                               .get(key, default)
+                               .get(key, internal_default)
 
     def set_global_default(self, key, value):
         cb = self.re_settings.get('cargo_build', {})
@@ -169,10 +180,13 @@ class CargoSettings(object):
         self._set_project_data()
 
     def get_global_variant(self, variant, key, default=None):
+        internal_default = CARGO_BUILD_DEFAULTS.get('variants', {})\
+                                               .get(variant, {})\
+                                               .get(key, default)
         return self.re_settings.get('cargo_build', {})\
                                .get('variants', {})\
                                .get(variant, {})\
-                               .get(key, default)
+                               .get(key, internal_default)
 
     def set_global_variant(self, variant, key, value):
         cb = self.re_settings.get('cargo_build', {})

--- a/rust/rust_proc.py
+++ b/rust/rust_proc.py
@@ -324,7 +324,7 @@ class RustProc(object):
         self.proc.stdout.close()
         rc = self.proc.wait()
         with PROCS_LOCK:
-            p = PROCS[self.window.id()]
+            p = PROCS.get(self.window.id())
             if p is self:
                 del PROCS[self.window.id()]
         return rc

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -152,8 +152,14 @@ class TestContext(TestBase):
         ]
         self.quick_panel_index = 2
         window.run_command('rust_list_messages')
-        new_view = window.active_view()
         expected_path = os.path.normpath(
             os.path.join(plugin_path, 'tests/message-order/examples/warning2.rs'))
-        self.assertEqual(new_view.file_name(), expected_path)
+        # Give Sublime some time to switch views.
+        for n in range(5):
+            new_view = window.active_view()
+            if new_view.file_name() == expected_path:
+                break
+            time.sleep(0.5)
+        else:
+            self.assertEqual(new_view.file_name(), expected_path)
         new_view.run_command('close_file')

--- a/tests/test_syntax_check.py
+++ b/tests/test_syntax_check.py
@@ -134,6 +134,8 @@ class TestSyntaxCheck(TestBase):
 
     def test_clippy_messages(self):
         """Test clippy messages."""
+        if self._skip_clippy():
+            return
         to_test = [
             'tests/error-tests/examples/clippy_ex.rs',
         ]

--- a/unittesting.json
+++ b/unittesting.json
@@ -1,3 +1,4 @@
 {
-	"async": true
+    "async": true,
+    "capture_console": true
 }


### PR DESCRIPTION
Includes changes:
- Change Clippy to default to run on Rust nightly.  We can change this once Clippy is distributed with stable.
- Various changes to make tests more robust.

Of course you will need to hook up Travis and AppVeyor to the repo.  I used defaults for everything except on AppVeyor I used the Visual Studio 2017 environment (instead of 2015).

These run stable/beta/nightly Rust as separate jobs.  The syntax tests run in every job.

I'm not an expert on either of these systems, so let me know if you want any changes.  Some notes:
- I left notifications at the default, which just send out an email.  Let me know if you would prefer something else, or if you want to add my email to the default notifiers.
- I didn't add the badges to the Readme.  We can add these if you want.
- We may want to consider setting up the cron/scheduling to force these to run periodically to catch problems with Rust nightly.

I'm still a little concerned about the tests being a little fragile since some of them are testing race conditions, but I've run them a fair number of times and they seem to be doing well for now.  Also, it's not unusual for Rust nightly to make minor changes to the diagnostic messages which trip up the tests.  Those are pretty easy to fix, though.  Nightly is also just broken sometimes.