### PR TITLE
Add support for checking tests in Rust 1.23.

### DIFF
--- a/RustEnhanced.sublime-settings
+++ b/RustEnhanced.sublime-settings
@@ -8,6 +8,7 @@
     "rust_syntax_checking_method": "check",
 
     // Enable checking of test code within #[cfg(test)] sections.
+    // `check` method requires Rust 1.23 or newer.
     "rust_syntax_checking_include_tests": true,
 
     // If true, will not display warning messages.

--- a/SyntaxCheckPlugin.py
+++ b/SyntaxCheckPlugin.py
@@ -2,7 +2,7 @@ import sublime
 import sublime_plugin
 import os
 from .rust import (messages, rust_proc, rust_thread, util, target_detect,
-                   cargo_settings)
+                   cargo_settings, semver)
 from pprint import pprint
 
 
@@ -152,6 +152,10 @@ class RustSyntaxCheckThread(rust_thread.RustThread, rust_proc.ProcListener):
                     # It also disables the "main function not found" error for
                     # binaries.
                     cmd['command'].append('--test')
+            elif method == 'check':
+                if (util.get_setting('rust_syntax_checking_include_tests', True) and
+                    semver.match(cmd['rustc_version'], '>=1.23.0')):
+                    cmd['command'].append('--profile=test')
             p = rust_proc.RustProc()
             self.current_target_src = target_src
             p.run(self.window, cmd['command'], self.cwd, self, env=cmd['env'])

--- a/tests/error-tests/examples/no_main.rs
+++ b/tests/error-tests/examples/no_main.rs
@@ -2,6 +2,8 @@
 
 mod no_main_mod;
 // Not sure why no-trans doesn't handle this properly.
-// end-msg: ERR(check) main function not found
-// end-msg: NOTE(check) the main function must be defined
-// end-msg: MSG(check) Note: no_main_mod.rs:1
+// When --profile=test is used with `cargo check`, this error will not happen
+// due to the synthesized main created by the test harness.
+// end-msg: ERR(rust_syntax_checking_include_tests=False) main function not found
+// end-msg: NOTE(rust_syntax_checking_include_tests=False) the main function must be defined
+// end-msg: MSG(rust_syntax_checking_include_tests=False) Note: no_main_mod.rs:1

--- a/tests/error-tests/examples/no_main_mod.rs
+++ b/tests/error-tests/examples/no_main_mod.rs
@@ -1,7 +1,7 @@
 /*BEGIN*/fn main() {
-//       ^^^^^^^^^WARN(no-trans) function is never used
-//       ^^^^^^^^^NOTE(no-trans) #[warn(dead_code)]
+//       ^^^^^^^^^WARN(rust_syntax_checking_include_tests=True) function is never used
+//       ^^^^^^^^^NOTE(rust_syntax_checking_include_tests=True) #[warn(dead_code)]
 // 1.24 nightly has changed how these no-trans messages are displayed (instead
 // of encompassing the entire function).
 }/*END*/
-// ~NOTE(check) here is a function named 'main'
+// ~NOTE(rust_syntax_checking_include_tests=False) here is a function named 'main'

--- a/tests/error-tests/src/lib.rs
+++ b/tests/error-tests/src/lib.rs
@@ -4,8 +4,8 @@ mod tests {
 //            ^^^^^^^^^^^^ERR(<1.16.0) undefined or not in scope
 //            ^^^^^^^^^^^^ERR(<1.16.0) type name
 //            ^^^^^^^^^^^^HELP(<1.16.0) no candidates
-//            ^^^^^^^^^^^^ERR(>=1.16.0,test) not found in this scope
-//            ^^^^^^^^^^^^ERR(>=1.16.0,test) cannot find type `DoesNotExist`
+//            ^^^^^^^^^^^^ERR(>=1.16.0,rust_syntax_checking_include_tests=True) not found in this scope
+//            ^^^^^^^^^^^^ERR(>=1.16.0,rust_syntax_checking_include_tests=True) cannot find type `DoesNotExist`
     }
 
     #[test]
@@ -13,7 +13,7 @@ mod tests {
         asdf
 //      ^^^^ERR(<1.16.0) unresolved name
 //      ^^^^ERR(<1.16.0) unresolved name
-//      ^^^^ERR(>=1.16.0,test) not found in this scope
-//      ^^^^ERR(>=1.16.0,test) cannot find value
+//      ^^^^ERR(>=1.16.0,rust_syntax_checking_include_tests=True) not found in this scope
+//      ^^^^ERR(>=1.16.0,rust_syntax_checking_include_tests=True) cannot find value
     }
 }

--- a/tests/rust_test_common.py
+++ b/tests/rust_test_common.py
@@ -172,3 +172,6 @@ class AlteredSetting(object):
 
     def __exit__(self, type, value, traceback):
         self.settings.set(self.name, self.orig)
+
+    def __str__(self):
+        return '%s=%s' % (self.name, self.value)


### PR DESCRIPTION
This fixes `rust_syntax_checking_include_tests` so that it works with `cargo check` so that tests are validated with on-save checking.  Uses the `--profile test` feature in Rust 1.23.

Closes #171.
