### PR TITLE
Highlight `let`, `static`, `const` as `storage.type.rust`

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -102,7 +102,7 @@ contexts:
         - include: statements-block
 
     - match: \b(let|const|static)\b
-      scope: storage.type.rust keyword.other.rust
+      scope: storage.type.rust
 
     - match: \bfn\b
       scope: storage.type.function.rust


### PR DESCRIPTION
With `keyword.other.rust` at the end, it ends up being "on top of the highlight stack", and the `storage.type.rust` highlighting gets overridden. So, I've removed the `keyword.other.rust` here.