### PR TITLE
Auto match raw strings.

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,6 +1,62 @@
 [
-    // Disable auto-pair for single quote
+    // Disable auto-pair for single quote since it is often used for lifetimes.
     { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'"}, "context":
         [{ "key": "selector", "operator": "equal", "operand": "source.rust" }]
-    }
+    },
+    // ' in b'c' will skip past the end quote.
+    { "keys": ["'"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^'", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.rust - punctuation.definition.string.begin" },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true },
+        ]
+    },
+    // b' will expand to b''
+    { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'$0'"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "b$", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.rust" },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true }
+
+        ]
+    },
+    // r" will expand to r""
+    // b" will expand to b""
+    { "keys": ["\""], "command": "insert_snippet", "args": {"contents": "\"$0\""}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "[rb]$", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.rust" },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true }
+        ]
+    },
+    // r# will expand to r#""#
+    // Additional # characters will be duplicated on both sides.
+    { "keys": ["#"], "command": "insert_snippet", "args": {"contents": "#$1\"$0\"${1/[^#]/$1/}#"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "r$", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.rust" },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double - punctuation.definition.string.end", "match_all": true }
+        ]
+    },
+    // # will skip past the # at the end of r#""#
+    { "keys": ["#"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^#", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.rust string.quoted.double.raw punctuation.definition.string.end" },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.double.raw - punctuation.definition.string.end", "match_all": true },
+        ]
+    },
 ]


### PR DESCRIPTION
This makes it a little easier to type raw strings.

Example:
![raw_strings](https://user-images.githubusercontent.com/43198/37744449-7481178c-2d2c-11e8-8a3d-a742d7dd4cde.gif)
