### PR TITLE
Remove semicolon from the fn snippet

### DIFF
--- a/snippets/fn.sublime-snippet
+++ b/snippets/fn.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[fn ${1:name}(${2:arg}: ${3:Type}) -> ${4:RetType} {
-    ${5:unimplemented!();}
+    ${5:unimplemented!()}
 }]]></content>
     <tabTrigger>fn</tabTrigger>
     <scope>source.rust</scope>


### PR DESCRIPTION
This allow users to compile an unimplemented function that don't return `unit` without having to edit this snippet.