### PR TITLE
add a snippet to create a tests module

### DIFF
--- a/snippets/tests-mod.sublime-snippet
+++ b/snippets/tests-mod.sublime-snippet
@@ -9,6 +9,6 @@ mod tests {
         ${2:unimplemented!();}
     }
 }]]></content>
-    <tabTrigger>tests</tabTrigger>
+    <tabTrigger>tests-mod</tabTrigger>
     <scope>source.rust</scope>
 </snippet>

--- a/snippets/tests.sublime-snippet
+++ b/snippets/tests.sublime-snippet
@@ -1,0 +1,14 @@
+<snippet>
+    <content><![CDATA[
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ${1:name}() {
+        ${2:unimplemented!();}
+    }
+}]]></content>
+    <tabTrigger>tests</tabTrigger>
+    <scope>source.rust</scope>
+</snippet>


### PR DESCRIPTION
I find myself copy-pasting a tests module from another location very frequently, so I created a snippet to quickly create it from scratch. Maybe its also useful to other people. 
I'm not sure if `tests` is a great key since that might cause mistyping when one actually just wants a `test` and not a whole module, so if anyone has a better suggestion, your feedback would be welcome.