### PR TITLE
fn snippet: only display arrow if return type is present

### DIFF
--- a/snippets/fn.sublime-snippet
+++ b/snippets/fn.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[fn ${1:name}(${2:arg}: ${3:Type}) ${4/(^.+$)|^$/(?1:-> :)/}${4:RetType} {
+    <content><![CDATA[fn ${1:name}(${2:arg}: ${3:Type}) ${4/(^.+$)|^$/(?1:-> :)/}${4:RetType}${4/(^.+$)|^$/(?1: :)/}{
     ${5:unimplemented!()}
 }]]></content>
     <tabTrigger>fn</tabTrigger>

--- a/snippets/fn.sublime-snippet
+++ b/snippets/fn.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[fn ${1:name}(${2:arg}: ${3:Type}) -> ${4:RetType} {
+    <content><![CDATA[fn ${1:name}(${2:arg}: ${3:Type}) ${4/(^.+$)|^$/(?1:-> :)/}${4:RetType} {
     ${5:unimplemented!()}
 }]]></content>
     <tabTrigger>fn</tabTrigger>


### PR DESCRIPTION
Use some sublime snippet substitution magic to only display arrow if a return type is actually present. I found that trick in some snippets included in ST3.