### PR TITLE
Improve message word wrapping to make messages easier to read.

### DIFF
--- a/rust/messages.py
+++ b/rust/messages.py
@@ -8,6 +8,7 @@ import html
 import itertools
 import os
 import re
+import textwrap
 import urllib.parse
 import uuid
 import webbrowser
@@ -90,7 +91,7 @@ class Message:
         for child in self.children:
             yield child
 
-    def escaped_text(self, indent):
+    def escaped_text(self, view, indent):
         """Returns the minihtml markup of the message.
 
         :param indent: String used for indentation when the message spans
@@ -102,18 +103,26 @@ class Message:
         if not self.text:
             return ''
 
+        # Call rstrip() because sometimes rust includes newlines at the
+        # end of the message, which we don't want.
+        text = self.text.rstrip()
+        if not view.settings().get('word_wrap', False):
+            # Rough assumption of using monospaced font, but should be
+            # reasonable in most cases for proportional fonts.
+            width = view.viewport_extent()[0] / view.em_width() - 5
+            text = textwrap.fill(self.text, width=width,
+                break_long_words=False, break_on_hyphens=False)
+
         def escape_and_link(i_txt):
             i, txt = i_txt
             if i % 2:
                 return '<a href="%s">%s</a>' % (txt, txt)
             else:
-                # Call strip() because sometimes rust includes newlines at the
-                # end of the message, which we don't want.
-                escaped = html.escape(txt.strip(), quote=False)
+                escaped = html.escape(txt, quote=False)
                 return re.sub('^( +)', lambda m: '&nbsp;'*len(m.group()), escaped, flags=re.MULTILINE)\
                     .replace('\n', '<br>' + indent)
 
-        parts = re.split(LINK_PATTERN, self.text)
+        parts = re.split(LINK_PATTERN, text)
         return ' '.join(map(escape_and_link, enumerate(parts)))
 
     def is_similar(self, other):
@@ -278,7 +287,7 @@ def message_popup(view, point, hover_zone):
 
     if batches:
         theme = themes.THEMES[util.get_setting('rust_message_theme')]
-        minihtml = '\n'.join(theme.render(batch, for_popup=True) for batch in batches)
+        minihtml = '\n'.join(theme.render(view, batch, for_popup=True) for batch in batches)
         if not minihtml:
             return
         on_nav = functools.partial(_click_handler, view, hide_popup=True)
@@ -349,7 +358,7 @@ def _show_phantom(view, batch):
         )
 
     theme = themes.THEMES[util.get_setting('rust_message_theme')]
-    content = theme.render(batch)
+    content = theme.render(view, batch)
     if not content:
         return
 
@@ -923,12 +932,19 @@ def _collect_rust_messages(window, base_path, info, target_path,
             replacement_template = util.multiline_fix("""
                 <div class="rust-replacement"><a href="replace:%s" class="rust-button">Accept Replacement:</a> %s</div>
             """)
+            html_suggestion = html.escape(span['suggested_replacement'], quote=False)
+            if '\n' in html_suggestion:
+                # Start on a new line so the text doesn't look too weird.
+                html_suggestion = '\n' + html_suggestion
+            html_suggestion = html_suggestion\
+                .replace(' ', '&nbsp;')\
+                .replace('\n', '<br>\n')
             child.minihtml_text = replacement_template % (
                 urllib.parse.urlencode({
                     'id': child.id,
                     'replacement': span['suggested_replacement'],
                 }),
-                html.escape(span['suggested_replacement'], quote=False),
+                html_suggestion,
             )
 
     # Recurse into children (which typically hold notes).

--- a/rust/themes.py
+++ b/rust/themes.py
@@ -19,7 +19,7 @@ class Theme:
 
     """Base class for themes."""
 
-    def render(self, batch, for_popup=False):
+    def render(self, view, batch, for_popup=False):
         """Return a minihtml string of the content in the message batch."""
         raise NotImplementedError()
 
@@ -85,7 +85,7 @@ class ClearTheme(Theme):
         </div>
     """)
 
-    def render(self, batch, for_popup=False):
+    def render(self, view, batch, for_popup=False):
         if for_popup:
             extra_css = POPUP_CSS
         else:
@@ -95,7 +95,7 @@ class ClearTheme(Theme):
         msgs = []
         last_level = None
         for i, msg in enumerate(batch):
-            text = msg.escaped_text('')
+            text = msg.escaped_text(view, '')
             if not text:
                 continue
             if msg.minihtml_text:
@@ -231,7 +231,7 @@ class SolidTheme(Theme):
         <div class="rust-links"><a href="{url}" class="rust-button">{text} {path}</a></div>
     """)
 
-    def render(self, batch, for_popup=False):
+    def render(self, view, batch, for_popup=False):
 
         def icon(level):
             # minihtml does not support switching resolution for images based on DPI.
@@ -258,7 +258,7 @@ class SolidTheme(Theme):
                 child_icon = icon('none')
             else:
                 child_icon = icon(child.level)
-            minihtml_text = child.escaped_text('&nbsp;' + icon('none'))
+            minihtml_text = child.escaped_text(view, '&nbsp;' + icon('none'))
             if minihtml_text:
                 txt = self.CHILD_TMPL.format(level=child.level,
                                              icon=child_icon,
@@ -271,7 +271,7 @@ class SolidTheme(Theme):
                 links.append(
                     self.LINK_TMPL.format(
                         url=url, text='See Also:', path=path))
-            text = batch.primary_message.escaped_text('')
+            text = batch.primary_message.escaped_text(view, '')
             if not text and not children:
                 return None
             content = self.PRIMARY_MSG_TMPL.format(
@@ -304,7 +304,7 @@ class TestTheme(Theme):
     def __init__(self):
         self.path_messages = {}
 
-    def render(self, batch, for_popup=False):
+    def render(self, view, batch, for_popup=False):
         from .messages import Message
         messages = self.path_messages.setdefault(batch.first().path, [])
         for msg in batch:

--- a/tests/test_syntax_check.py
+++ b/tests/test_syntax_check.py
@@ -255,7 +255,7 @@ class TestSyntaxCheck(TestBase):
                                               .get(view.file_name(), [])
             theme_data[theme] = output = []
             for batch in batches:
-                output.append(themes.THEMES[theme].render(batch))
+                output.append(themes.THEMES[theme].render(view, batch))
         # Check that the message appears *somewhere*.  This is just a rough
         # verification.
         for emsg_info in expected_messages:


### PR DESCRIPTION
Example where this makes a significant improvement:

<img width="571" alt="image" src="https://user-images.githubusercontent.com/43198/40801363-98a45d5e-64c7-11e8-9449-2b8b8b2f7c50.png">
