### PR TITLE
Support diagnostics with multiple suggestions.

### DIFF
--- a/rust/batch.py
+++ b/rust/batch.py
@@ -115,4 +115,4 @@ class ChildBatch(MessageBatch):
 
     def dismiss(self, window):
         self.hidden = True
-        self.primary_batch.dismiss(window)
+        self._dismiss(window)


### PR DESCRIPTION
Previously, when you accepted a suggestion, all of the others would disappear.