### PR TITLE
properly escape + repeat operator for operator matching

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -249,7 +249,7 @@ contexts:
     - match: '>=|<=|==|!=|&&|\|\|'
       scope: keyword.operator.rust
 
-    - match: '\*=|/=|+=|-=|%=|\^='
+    - match: '\*=|/=|\+=|-=|%=|\^='
       scope: keyword.operator.rust
 
     - match: '[-=<>&|!~@?+*/%^''#$]'


### PR DESCRIPTION
Prior to this change the `+` in matching the literal `+=` was not escaped properly (in the same way that `*` in literal `*=` and `^` in literal `^=`) are.

This meant that the regexp here was not technically valid, because the prior character was the regexp OR `|` operator.

For some reason, Sublime doesn't seem to complain about such errors -- however [Syntect](https://github.com/trishume/syntect/pull/166) (which recently got stricter about regexp parsing) does:

```
ParseSyntax(RegexCompileError("\\=|/=|+=|-=|%=|\\^=", Error(-113, target of repeat operator is not specified)))
```

After this change, the syntax is now valid regexp and works with the latest version of Syntect.