### PR TITLE
Add ".rust" to semicolon scope.

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -26,7 +26,7 @@ contexts:
   statements:
 
     - match: ';'
-      scope: punctuation.terminator
+      scope: punctuation.terminator.rust
 
     - match: '''({{identifier}})\s*(:)'
       captures:


### PR DESCRIPTION
This doesn't really change anything, but I think it should be included.