### PR TITLE
CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # This is for when a pull request is opened.
+    - master
+
 env:
   global:
     - PACKAGE="Rust Enhanced"
@@ -39,15 +48,13 @@ install:
   # Pin a known good version of nightly and clippy.
   - >
     if [ "$TRAVIS_RUST_VERSION" != "nightly" ]; then
-      rustup install nightly-2018-05-26;
+      rustup install nightly-2018-08-04;
       host=$(rustc -Vv | grep ^host: | sed -e "s/host: //g");
       toolchains=$(dirname $(dirname $(dirname $(rustup which rustc))));
       mv $toolchains/nightly-* $toolchains/nightly-$host;
-      cargo +nightly install --version 0.0.205 clippy || export RE_SKIP_CLIPPY=1;
-    else
-      cargo +nightly install clippy || export RE_SKIP_CLIPPY=1;
     fi
   # Install Rust packages needed by integration tests.
+  - rustup component add clippy-preview --toolchain=nightly
   - cargo install cargo-script
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,32 +1,55 @@
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # This is for when a pull request is opened.
+    - master
+
 environment:
-    global:
-        PACKAGE: "Rust Enhanced"
-        SUBLIME_TEXT_VERSION : "3"
+  global:
+    PACKAGE: "Rust Enhanced"
+    SUBLIME_TEXT_VERSION : "3"
 
-    matrix:
-        - RUST_VERSION: stable
-        - RUST_VERSION: beta
-        - RUST_VERSION: nightly
+  matrix:
+    - RUST_VERSION: stable
+    - RUST_VERSION: beta
+    - RUST_VERSION: nightly
 
+matrix:
+  allow_failures:
+    - RUST_VERSION: beta
+    - RUST_VERSION: nightly
 
 install:
-    - ps: appveyor DownloadFile "https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/appveyor.ps1"
-    # Install Sublime and Sublime Unittesting.
-    - ps: .\appveyor.ps1 "bootstrap" -verbose
-    - ps: .\appveyor.ps1 "install_package_control" -verbose
-    # Install rust.
-    - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-    - rustup-init.exe -y --default-toolchain %RUST_VERSION%
-    - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
-    # Ensure nightly is installed to run benchmarks and Clippy.
-    - rustup install nightly
-    # Install Rust packages needed by integration tests.
-    - cargo +nightly install clippy || set RE_SKIP_CLIPPY=1
-    - cargo install cargo-script
-    - rustc -Vv
+  - ps: appveyor DownloadFile "https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/appveyor.ps1"
+  # Install Sublime and Sublime Unittesting.
+  - ps: .\appveyor.ps1 "bootstrap" -verbose
+  - ps: .\appveyor.ps1 "install_package_control" -verbose
+  # Install rust.
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-toolchain %RUST_VERSION%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  # Ensure nightly is installed to run benchmarks and Clippy.
+  # Pin a known good version of nightly.
+  - ps: |-
+      If ($env:RUST_VERSION -ne "nightly") {
+        # Workaround an odd issue where stderr is treated as an exception, and
+        # you cannot even redirect native commands to stdout!
+        cmd /c "rustup install nightly-2018-08-04 2>&1"
+        ((rustc -Vv) | out-string) -match "host: (\S*)"
+        $rust_host=$matches[1]
+        $toolchains=(split-path (split-path (split-path (rustup which rustc))))
+        mv $toolchains/nightly-* $toolchains/nightly-$rust_host
+      }
+  # Install Rust packages needed by integration tests.
+  - rustup component add clippy-preview --toolchain=nightly
+  - cargo install cargo-script
+  - rustc -Vv
 
 build: off
 
 test_script:
-    - ps: .\appveyor.ps1 "run_syntax_tests" -verbose
-    - ps: .\appveyor.ps1 "run_tests" -verbose
+  - ps: .\appveyor.ps1 "run_syntax_tests" -verbose
+  - ps: .\appveyor.ps1 "run_tests" -verbose

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,3 @@
+status = [
+  "continuous-integration/travis-ci/push",
+]


### PR DESCRIPTION
- Set branches for bors.
- Update the pinned nightly.
- Update appveyor to use pinned nightly.
- Use clippy component instead of building it.