### PR TITLE
Syntax: Support *const raw pointer in (some) type positions.

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -490,7 +490,7 @@ contexts:
     - include: return-type
     - match: '&'
       scope: keyword.operator.rust
-    - match: \b(mut|ref)\b
+    - match: \b(mut|ref|const)\b
       scope: storage.modifier.rust
     - match: \b(fn)\b(\()
       captures:

--- a/tests/syntax-rust/syntax_test_functions.rs
+++ b/tests/syntax-rust/syntax_test_functions.rs
@@ -66,3 +66,10 @@ let f: extern "C" fn () = mem::transmute(0xffff0fa0u32);
 //                      ^ keyword.operator
 //                                       ^^^^^^^^^^ meta.group constant.numeric.integer.hexadecimal
 //                                                 ^^^ meta.group storage.type.numeric
+
+// Raw pointer in a parameter.
+fn f(a: *const u8, b: *mut i8) {}
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
+//       ^^^^^ storage.modifier
+//                     ^^^ storage.modifier


### PR DESCRIPTION
This doesn't handle everything (like `let x: *const u8 = ...`),
but that's a whole other can of worms.

<img width="583" alt="image" src="https://user-images.githubusercontent.com/43198/43736162-87f4041c-9971-11e8-9f6d-099bbb1fea3b.png">
