### PR TITLE
Syntax: Fix unsafe prefix for function types.

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -472,7 +472,7 @@ contexts:
     - include: return-type
     - match: '&'
       scope: keyword.operator.rust
-    - match: \b(mut|ref|const)\b
+    - match: \b(mut|ref|const|unsafe)\b
       scope: storage.modifier.rust
     - match: \b(fn)\b(\()
       captures:

--- a/tests/syntax-rust/syntax_test_misc.rs
+++ b/tests/syntax-rust/syntax_test_misc.rs
@@ -9,6 +9,9 @@ unsafe impl<T> Send for Interned<T> {}
 //^^^^ storage.modifier
 pub unsafe trait Alloc { }
 //  ^^^^^^ storage.modifier
+fn f(a: unsafe fn() -> String) {}
+//      ^^^^^^ meta.function meta.function.parameters storage.modifier
+//             ^^ meta.function meta.function.parameters storage.type.function
 
 // Previously reserved keywords now unreserved.
 let pure = 1;


### PR DESCRIPTION
<img width="603" alt="image" src="https://user-images.githubusercontent.com/43198/43736495-a13d96d0-9972-11e8-82bf-55cc4c05a61e.png">
