### PR TITLE
cargo doc: Support JSON messages.

### DIFF
--- a/rust/cargo_settings.py
+++ b/rust/cargo_settings.py
@@ -88,7 +88,7 @@ CARGO_COMMANDS = {
         'allows_target_triple': True,
         'allows_release': True,
         'allows_features': True,
-        'allows_json': False,
+        'allows_json': True,
     },
     'clippy': {
         'name': 'Clippy',

--- a/tests/doc/Cargo.toml
+++ b/tests/doc/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "doc"
+version = "0.1.0"
+
+[dependencies]

--- a/tests/doc/src/lib.rs
+++ b/tests/doc/src/lib.rs
@@ -1,0 +1,11 @@
+/// Doc example.
+/// See [`beta`].
+pub fn alpha() {
+
+}
+
+/// Example
+/// See [`oops`].
+pub fn beta() {
+
+}

--- a/tests/doc/src/main.rs
+++ b/tests/doc/src/main.rs
@@ -1,0 +1,1 @@
+compile_error!{"Forced error"}


### PR DESCRIPTION
1.30 has added support for JSON messages with rustdoc. This allows the build
command to capture errors and warnings for rustdoc. Previously messages were
only displayed in the build panel (older versions will continue to behave this way).

<img width="644" alt="image" src="https://user-images.githubusercontent.com/43198/44379176-9e819e80-a4b9-11e8-9c6b-e4c77815cafc.png">
