### PR TITLE
Syntax: Index `const` and `static` symbols (for Goto-Symbol).

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -101,6 +101,17 @@ contexts:
       scope: storage.type.enum.rust
       push: enum-identifier
 
+    - match: '\b(const)\s+({{identifier}})'
+      captures:
+        1: storage.type.rust
+        2: entity.name.constant.rust
+
+    - match: '\b(static)\s+(?:(mut)\s+)?({{identifier}})'
+      captures:
+        1: storage.type.rust
+        2: storage.modifier.rust
+        3: entity.name.constant.rust
+
     - match: '\b(break|continue)(?:\s+(''{{identifier}}))?'
       captures:
         1: keyword.control.rust

--- a/RustSymbols.JSON-tmPreferences
+++ b/RustSymbols.JSON-tmPreferences
@@ -1,6 +1,6 @@
 {
     "name": "Rust Symbols",
-    "scope": "entity.name.function.rust, entity.name.macro.rust, entity.name.struct.rust, entity.name.enum.rust, entity.name.module.rust, entity.name.type.rust, entity.name.trait.rust",
+    "scope": "entity.name.function.rust, entity.name.macro.rust, entity.name.struct.rust, entity.name.enum.rust, entity.name.module.rust, entity.name.type.rust, entity.name.trait.rust, entity.name.constant.rust",
     "settings": {
         "showInSymbolList": 1,
         "showInIndexedSymbolList": 1

--- a/RustSymbols.tmPreferences
+++ b/RustSymbols.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Rust Symbols</string>
 	<key>scope</key>
-	<string>entity.name.function.rust, entity.name.macro.rust, entity.name.struct.rust, entity.name.enum.rust, entity.name.module.rust, entity.name.type.rust, entity.name.trait.rust</string>
+	<string>entity.name.function.rust, entity.name.macro.rust, entity.name.struct.rust, entity.name.enum.rust, entity.name.module.rust, entity.name.type.rust, entity.name.trait.rust, entity.name.constant.rust</string>
 	<key>settings</key>
 	<dict>
 		<key>showInIndexedSymbolList</key>

--- a/tests/syntax-rust/syntax_test_types.rs
+++ b/tests/syntax-rust/syntax_test_types.rs
@@ -33,19 +33,23 @@ type GenFnPointer2 = Bar<extern "C" fn()>;
 
 const ZERO: u64 = 0;
 // <- storage.type
-//    ^^^^ constant.other
+//    ^^^^ entity.name.constant
 //        ^ punctuation.separator
 //          ^^^ storage.type
 //              ^ keyword.operator
 //                ^ constant.numeric.integer.decimal
 static NAME: &'static str = "John";
 // <- storage.type
+//     ^^^^ entity.name.constant
 //           ^ keyword.operator
 //            ^^^^^^^ storage.modifier.lifetime
 //                    ^^^ storage.type
 //                        ^ keyword.operator
 //                          ^^^^^^ string.quoted.double
-
+static mut BRAVO: u32 = 0;
+// <- storage.type
+//     ^^^ storage.modifier
+//         ^^^^^ entity.name.constant
 
 // Function type in a box return type.
 // fixes https://github.com/rust-lang/sublime-rust/issues/144


### PR DESCRIPTION
This changes the scope to `entity.name.constant`. Depending on your color
scheme, this will likely change the color from the old `constant.other` scope.
I think this better follows the spirit of Sublime's naming conventions.

<img width="606" alt="image" src="https://user-images.githubusercontent.com/43198/44379270-00420880-a4ba-11e8-8eb1-2717b9476043.png">
