### PR TITLE
Snippets: change hard-coded 4 spaces to tab charaters

### DIFF
--- a/snippets/bench.sublime-snippet
+++ b/snippets/bench.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 #[bench]
 fn ${1:name}(b: &mut test::Bencher) {
-    ${2:b.iter(|| ${3:/* benchmark code */})}
+	${2:b.iter(|| ${3:/* benchmark code */})}
 }]]></content>
     <tabTrigger>bench</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/else.sublime-snippet
+++ b/snippets/else.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[else {
-    ${1:unimplemented!();}
+	${1:unimplemented!();}
 }]]></content>
     <tabTrigger>else</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/enum.sublime-snippet
+++ b/snippets/enum.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
     <content><![CDATA[#[derive(Debug)]
 enum ${1:Name} {
-    ${2:Variant1},
-    ${3:Variant2},
+	${2:Variant1},
+	${3:Variant2},
 }]]></content>
     <tabTrigger>enum</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/extern-fn.sublime-snippet
+++ b/snippets/extern-fn.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[extern "C" fn ${1:name}(${2:arg}: ${3:Type}) -> ${4:RetType} {
-    ${5:// add code here}
+	${5:// add code here}
 }]]></content>
     <tabTrigger>extern-fn</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/extern-mod.sublime-snippet
+++ b/snippets/extern-mod.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[extern "C" {
-    ${2:// add code here}
+	${2:// add code here}
 }]]></content>
     <tabTrigger>extern-mod</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/fn.sublime-snippet
+++ b/snippets/fn.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[fn ${1:name}(${2:arg}: ${3:Type}) ${4/(^.+$)|^$/(?1:-> :)/}${4:RetType}${4/(^.+$)|^$/(?1: :)/}{
-    ${5:unimplemented!()}
+	${5:unimplemented!()}
 }]]></content>
     <tabTrigger>fn</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/for.sublime-snippet
+++ b/snippets/for.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[for ${1:pat} in ${2:expr} {
-    ${3:unimplemented!();}
+	${3:unimplemented!();}
 }]]></content>
     <tabTrigger>for</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/if-let.sublime-snippet
+++ b/snippets/if-let.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[if let ${1:Some(pat)} = ${2:expr} {
-    ${3:unimplemented!();}
+	${3:unimplemented!();}
 }]]></content>
     <tabTrigger>if-let</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/if.sublime-snippet
+++ b/snippets/if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[if ${1:condition} {
-    ${2:unimplemented!();}
+	${2:unimplemented!();}
 }]]></content>
     <tabTrigger>if</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/impl-trait.sublime-snippet
+++ b/snippets/impl-trait.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[impl ${1:Trait} for ${2:Type} {
-    ${3:// add code here}
+	${3:// add code here}
 }]]></content>
     <tabTrigger>impl-trait</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/impl.sublime-snippet
+++ b/snippets/impl.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[impl ${1:Type} {
-    ${2:// add code here}
+	${2:// add code here}
 }]]></content>
     <tabTrigger>impl</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/loop.sublime-snippet
+++ b/snippets/loop.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[loop {
-    ${2:unimplemented!();}
+	${2:unimplemented!();}
 }]]></content>
     <tabTrigger>loop</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/macro_rules.sublime-snippet
+++ b/snippets/macro_rules.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[macro_rules! ${1:name} {
-    (${2}) => (${3})
+	(${2}) => (${3})
 }]]></content>
     <tabTrigger>macro_rules</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/main.sublime-snippet
+++ b/snippets/main.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[fn main() {
-    ${1:unimplemented!();}
+	${1:unimplemented!();}
 }]]></content>
     <tabTrigger>main</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/match.sublime-snippet
+++ b/snippets/match.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[match ${1:expr} {
-    ${2:Some(expr)} => ${3:expr},
-    ${4:None} => ${5:expr},
+	${2:Some(expr)} => ${3:expr},
+	${4:None} => ${5:expr},
 }]]></content>
     <tabTrigger>match</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/mod.sublime-snippet
+++ b/snippets/mod.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[mod ${1:name} {
-    ${2:// add code here}
+	${2:// add code here}
 }]]></content>
     <tabTrigger>mod</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/struct.sublime-snippet
+++ b/snippets/struct.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[#[derive(Debug)]
 struct ${1:Name} {
-    ${2:field}: ${3:Type}
+	${2:field}: ${3:Type}
 }]]></content>
     <tabTrigger>struct</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/test.sublime-snippet
+++ b/snippets/test.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 #[test]
 fn ${1:name}() {
-    ${2:unimplemented!();}
+	${2:unimplemented!();}
 }]]></content>
     <tabTrigger>test</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/tests-mod.sublime-snippet
+++ b/snippets/tests-mod.sublime-snippet
@@ -2,12 +2,12 @@
     <content><![CDATA[
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn ${1:name}() {
-        ${2:unimplemented!();}
-    }
+	#[test]
+	fn ${1:name}() {
+		${2:unimplemented!();}
+	}
 }]]></content>
     <tabTrigger>tests-mod</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/trait.sublime-snippet
+++ b/snippets/trait.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[trait ${1:Name} {
-    ${2:// add code here}
+	${2:// add code here}
 }
 ]]></content>
     <tabTrigger>trait</tabTrigger>

--- a/snippets/while-let.sublime-snippet
+++ b/snippets/while-let.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[while let ${1:Some(pat)} = ${2:expr} {
-    ${3:unimplemented!();}
+	${3:unimplemented!();}
 }]]></content>
     <tabTrigger>while-let</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/while.sublime-snippet
+++ b/snippets/while.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[while ${1:condition} {
-    ${2:unimplemented!();}
+	${2:unimplemented!();}
 }]]></content>
     <tabTrigger>while</tabTrigger>
     <scope>source.rust</scope>


### PR DESCRIPTION
When using snippets, Sublime Text expands the tabs based on user preferences. This way users who use 2-space indentation will get 2 spaces when using a snippet, users who use 4-space indentation will get 4 spaces, and users who use tabs will get tabs. 

I realize that the vast majority of Rust code seems to be 4-space indented, and that looks to be the encouraged style, but, for my own code, I prefer 2-space indentation, and I don't think this change necessarily goes against the 4-space style. The only imposition for future changes is that multi-line indented snippets need to be saved with tab characters.