### PR TITLE
Syntax: Support `vis` macro designator.

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -742,7 +742,7 @@ contexts:
           pop: true
         - include: macro-matchers
 
-    - match: '(\$\s*{{identifier}})\s*(:)\s*(ident|path|expr|ty|pat|stmt|block|item|meta|tt|lifetime)'
+    - match: '(\$\s*{{identifier}})\s*(:)\s*(ident|path|expr|ty|pat|stmt|block|item|meta|tt|lifetime|vis)'
       captures:
         1: variable.parameter.rust
         2: punctuation.separator.rust

--- a/tests/syntax-rust/syntax_test_macros.rs
+++ b/tests/syntax-rust/syntax_test_macros.rs
@@ -348,9 +348,13 @@ macro_rules! designators {
      $m:meta,
 //   ^^ variable.parameter
 //      ^^^^ storage.type
-     $l:lifetime) => ();
+     $l:lifetime,
 //   ^^ variable.parameter
 //      ^^^^^^^^ storage.type
+     $v:vis,
+//   ^^ variable.parameter
+//      ^^^ storage.type
+    ) => ();
     // And various tokens
     ("Any token" /*comment*/ true => 3.14 'life 'c' @ struct self) => ();
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.macro meta.macro.matchers


### PR DESCRIPTION
Stabilized in 1.30.