### PR TITLE
feat: add ability to customize status bar text

### DIFF
--- a/RustEnhanced.sublime-settings
+++ b/RustEnhanced.sublime-settings
@@ -57,6 +57,15 @@
     // If `true`, displays diagnostic messages under the cursor in the status bar.
     "rust_message_status_bar": false,
 
+    // The message to display when the syntax check is running.
+    "rust_message_status_bar_msg": "Rust check running",
+
+    // A list of chars that cycle through in the status bar to indicate progress.
+    "rust_message_status_bar_chars": [".", "..", "...", ".."],
+
+    // How often (ms) should the status bar text be updated when syntax checking.
+    "rust_message_status_bar_update_delay": 200,
+
     // If your cargo project has several build targets, it's possible to specify mapping of
     // source code filenames to the target names to enable syntax checking.
     // "projects": {

--- a/SyntaxCheckPlugin.py
+++ b/SyntaxCheckPlugin.py
@@ -112,13 +112,23 @@ class RustSyntaxCheckThread(rust_thread.RustThread, rust_proc.ProcListener):
     def update_status(self, count=0):
         if self.done:
             return
-        num = count % 4
-        if num == 3:
-            num = 1
-        num += 1
-        msg = 'Rust check running' + '.' * num
-        self.window.status_message(msg)
-        sublime.set_timeout(lambda: self.update_status(count + 1), 200)
+
+        status_msg = util.get_setting('rust_message_status_bar_msg')
+        status_chars = util.get_setting('rust_message_status_bar_chars')
+        status_update_delay = util.get_setting('rust_message_status_bar_update_delay')
+
+        try:
+            status_chars_len = len(status_chars)
+            num = count % status_chars_len
+            if num == status_chars_len - 1:
+                num = -1
+            num += 1
+
+            self.window.status_message(status_msg + status_chars[num])
+            sublime.set_timeout(lambda: self.update_status(count + 1), status_update_delay)
+        except Exception as e:
+            self.window.status_message('Error setting status text!')
+            log.critical(self.window, "An error occurred setting status text: " + str(e))
 
     def get_rustc_messages(self):
         """Top-level entry point for generating messages for the given


### PR DESCRIPTION
I wanted to be able to customise the status bar text while the syntax check was running. Here's that change!

It's "non-breaking", meaning that the text is still this:
👌 
![default](https://user-images.githubusercontent.com/34289614/48541048-d01ad200-e90f-11e8-9052-596072c1ea4c.gif)

And it allows you to customise the text like this:
🎉
![custom-1](https://user-images.githubusercontent.com/34289614/48541059-db6dfd80-e90f-11e8-92ea-d69ce89fe810.gif)
😮
![custom-2](https://user-images.githubusercontent.com/34289614/48541061-dd37c100-e90f-11e8-8d50-537f51367226.gif)

Or even this:
![custom-3](https://user-images.githubusercontent.com/34289614/48541303-72d35080-e910-11e8-94e7-effaa2101e53.gif)

(For a good collection of text-based spinners see [`cli-spinners`](https://github.com/sindresorhus/cli-spinners/blob/master/spinners.json)).