### PR TITLE
Syntax: Abort on invalid struct syntax.

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -611,6 +611,9 @@ contexts:
     - match: '\{'
       scope: punctuation.definition.block.begin.rust
       push: struct-classic-body
+    - match: '(?=\S)'
+      # Abort for an invalid match.
+      pop: true
 
   struct-classic-body:
     - meta_scope: meta.block.rust
@@ -628,7 +631,9 @@ contexts:
         - match: ':'
           scope: punctuation.separator.rust
         - include: type-any-identifier
-
+    - match: '(?=\S)'
+      # Abort for an invalid match.
+      pop: true
 
   union-identifier:
     - meta_scope: meta.union.rust


### PR DESCRIPTION
This helps with macros which use funky syntax.