### PR TITLE
Add syntax highlighting for `async/await/try` keyword

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -1393,7 +1393,7 @@ contexts:
     - match: \b(crate|extern|use|where)\b
       scope: keyword.other.rust
 
-    - match: \b(else|for|if|loop|match|while|yield)\b
+    - match: \b(async|await|else|for|if|loop|match|while|yield)\b
       scope: keyword.control.rust
 
     - match: \b(break|continue)\b

--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -1393,7 +1393,7 @@ contexts:
     - match: \b(crate|extern|use|where)\b
       scope: keyword.other.rust
 
-    - match: \b(async|await|else|for|if|loop|match|while|yield)\b
+    - match: \b(async|await|else|for|if|loop|match|try|while|yield)\b
       scope: keyword.control.rust
 
     - match: \b(break|continue)\b

--- a/tests/syntax-rust/syntax_test_misc.rs
+++ b/tests/syntax-rust/syntax_test_misc.rs
@@ -46,3 +46,13 @@ let override = 1;
 //  ^^^^^^^^ invalid.illegal.rust
 let macro = 1;
 //  ^^^^^ invalid.illegal.rust
+
+// async/await
+let x = async {}
+//      ^^^^^ keyword.control.rust
+let y = future.await;
+//             ^^^^^ keyword.control.rust
+
+// try keyword in 2018 edition
+let x = try {}
+//      ^^^ keyword.control.rust


### PR DESCRIPTION
Snippet:
```rust
async fn send_message(&self, content: &str) -> Result<MessageId, Error> {
    self.rate_limiter.acquire(1).await; // Acquire 1 permit of async semaphore
    
    let serialized_message = serializer.serialize(content);

    match writer.enqueue_message(serialized_message).await {
        Ok(id) => {
            // Sending the message was fully successful and the ownership had
            // had been passed. The permit now will get released when a response
            // is received.
            Ok(id)
        },
        Err(e) => {
            // Sending the message failed. Since the permit hasn't been used,
            // release it immediately.
            self.rate_limiter.release(1);
            Err(e)
        }
    }
}
```

After this change:
![image](https://user-images.githubusercontent.com/15225902/57970102-7d49d200-79a7-11e9-8de0-41d92328abc4.png)

Closes #377 