### PR TITLE
Explicitly set the "exit" point on some snippets.

### DIFF
--- a/snippets/Ok.sublime-snippet
+++ b/snippets/Ok.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[Ok(${1:result})]]></content>
+    <content><![CDATA[Ok(${0:result})]]></content>
     <tabTrigger>Ok</tabTrigger>
     <scope>source.rust</scope>
     <description>Ok(…)</description>

--- a/snippets/Some.sublime-snippet
+++ b/snippets/Some.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[Some(${1})]]></content>
+    <content><![CDATA[Some(${0})]]></content>
     <tabTrigger>Some</tabTrigger>
     <scope>source.rust</scope>
     <description>Some(…)</description>

--- a/snippets/bench.sublime-snippet
+++ b/snippets/bench.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 #[bench]
 fn ${1:name}(b: &mut test::Bencher) {
-	${2:b.iter(|| ${3:/* benchmark code */})}
+	${2:b.iter(|| ${0:/* benchmark code */})}
 }]]></content>
     <tabTrigger>bench</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/extern-fn.sublime-snippet
+++ b/snippets/extern-fn.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[extern "C" fn ${1:name}(${2:arg}: ${3:Type}) -> ${4:RetType} {
-	${5:// add code here}
+	${0:// add code here}
 }]]></content>
     <tabTrigger>extern-fn</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/extern-mod.sublime-snippet
+++ b/snippets/extern-mod.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[extern "C" {
-	${2:// add code here}
+	${0:// add code here}
 }]]></content>
     <tabTrigger>extern-mod</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/fn.sublime-snippet
+++ b/snippets/fn.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[fn ${1:name}(${2:arg}: ${3:Type}) ${4/(^.+$)|^$/(?1:-> :)/}${4:RetType}${4/(^.+$)|^$/(?1: :)/}{
-	${5:unimplemented!()}
+	${0:unimplemented!()}
 }]]></content>
     <tabTrigger>fn</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/for.sublime-snippet
+++ b/snippets/for.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[for ${1:pat} in ${2:expr} {
-	${3:unimplemented!();}
+	${0:unimplemented!();}
 }]]></content>
     <tabTrigger>for</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/if-let.sublime-snippet
+++ b/snippets/if-let.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[if let ${1:Some(pat)} = ${2:expr} {
-	${3:unimplemented!();}
+	${0:unimplemented!();}
 }]]></content>
     <tabTrigger>if-let</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/if.sublime-snippet
+++ b/snippets/if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[if ${1:condition} {
-	${2:unimplemented!();}
+	${0:unimplemented!();}
 }]]></content>
     <tabTrigger>if</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/impl-trait.sublime-snippet
+++ b/snippets/impl-trait.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[impl ${1:Trait} for ${2:Type} {
-	${3:// add code here}
+	${0:// add code here}
 }]]></content>
     <tabTrigger>impl-trait</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/impl.sublime-snippet
+++ b/snippets/impl.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[impl ${1:Type} {
-	${2:// add code here}
+	${0:// add code here}
 }]]></content>
     <tabTrigger>impl</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/loop.sublime-snippet
+++ b/snippets/loop.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[loop {
-	${2:unimplemented!();}
+	${0:unimplemented!();}
 }]]></content>
     <tabTrigger>loop</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/macro_rules.sublime-snippet
+++ b/snippets/macro_rules.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[macro_rules! ${1:name} {
-	(${2}) => (${3})
+	(${2}) => {${0}};
 }]]></content>
     <tabTrigger>macro_rules</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/main.sublime-snippet
+++ b/snippets/main.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[fn main() {
-	${1:unimplemented!();}
+	${0:unimplemented!();}
 }]]></content>
     <tabTrigger>main</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/mod.sublime-snippet
+++ b/snippets/mod.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[mod ${1:name} {
-	${2:// add code here}
+	${0:// add code here}
 }]]></content>
     <tabTrigger>mod</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/test.sublime-snippet
+++ b/snippets/test.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 #[test]
 fn ${1:name}() {
-	${2:unimplemented!();}
+	${0:unimplemented!();}
 }]]></content>
     <tabTrigger>test</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/tests-mod.sublime-snippet
+++ b/snippets/tests-mod.sublime-snippet
@@ -6,7 +6,7 @@ mod tests {
 
 	#[test]
 	fn ${1:name}() {
-		${2:unimplemented!();}
+		${0:unimplemented!();}
 	}
 }]]></content>
     <tabTrigger>tests-mod</tabTrigger>

--- a/snippets/trait.sublime-snippet
+++ b/snippets/trait.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[trait ${1:Name} {
-	${2:// add code here}
+	${0:// add code here}
 }
 ]]></content>
     <tabTrigger>trait</tabTrigger>

--- a/snippets/while-let.sublime-snippet
+++ b/snippets/while-let.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[while let ${1:Some(pat)} = ${2:expr} {
-	${3:unimplemented!();}
+	${0:unimplemented!();}
 }]]></content>
     <tabTrigger>while-let</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/while.sublime-snippet
+++ b/snippets/while.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[while ${1:condition} {
-	${2:unimplemented!();}
+	${0:unimplemented!();}
 }]]></content>
     <tabTrigger>while</tabTrigger>
     <scope>source.rust</scope>


### PR DESCRIPTION
Often when using a snippet, when you tab into the main "body" of the snippet, it
is still in snippet mode. This means that hitting tab will exit the body. This
is almost never what I want, since it disables tab completion.