### PR TITLE
Remove print/eprint snippet.

### DIFF
--- a/snippets/eprint.sublime-snippet
+++ b/snippets/eprint.sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-    <content><![CDATA[eprint!("${1:\{${2::?}\}}"${1/([^\{])*(\{.*\})?.*/(?2:, :\);)/}$3${1/([^\{])*(\{.*\})?.*/(?2:\);)/}]]></content>
-    <scope>source.rust</scope>
-    <tabTrigger>eprint</tabTrigger>
-    <description>eprint!(…)</description>
-</snippet>

--- a/snippets/print.sublime-snippet
+++ b/snippets/print.sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-    <content><![CDATA[print!("${1:\{${2::?}\}}"${1/([^\{])*(\{.*\})?.*/(?2:, :\);)/}$3${1/([^\{])*(\{.*\})?.*/(?2:\);)/}]]></content>
-    <scope>source.rust</scope>
-    <tabTrigger>print</tabTrigger>
-    <description>print!(…)</description>
-</snippet>


### PR DESCRIPTION
This removes the print! and eprint! snippets. They are used much less often
(about 5% of the time on crates.io), and often get in the way of wanting to
complete the `ln` versions. Snippets aren't really a replacement for full
completion, and I think should be reserved for common templates. If the user
really wants the non-`ln` version, they can just type it manually, or delete
the `ln` after completion. If the user really wants these snippets, they
can be added back into their User directory.

Closes #375.
