### PR TITLE
Add "Document (with args)" build command

### DIFF
--- a/RustEnhanced.sublime-build
+++ b/RustEnhanced.sublime-build
@@ -48,6 +48,13 @@
             "command": "doc",
         },
         {
+            "name": "Document (with args)...",
+            "command": "doc",
+            "command_info": {
+                "wants_run_args": true
+            }
+        },
+        {
             "name": "Clippy",
             "command": "clippy",
         },


### PR DESCRIPTION
Some people may want to run "cargo doc --open" or some other "cargo doc" variant, why not just let them do it directly from sublime?