### PR TITLE
Next/prev jump to end of span.

### DIFF
--- a/rust/messages.py
+++ b/rust/messages.py
@@ -551,7 +551,7 @@ def _show_message(window, current_idx, transient=False, force_open=False):
             # show_at_center is buggy with newly opened views (see
             # https://github.com/SublimeTextIssues/Core/issues/538).
             # ENCODED_POSITION is 1-based.
-            row, col = msg.span[0]
+            row, col = msg.span[1]
         else:
             row, col = (999999999, 1)
         view = window.open_file('%s:%d:%d' % (path, row + 1, col + 1),
@@ -586,7 +586,7 @@ def _scroll_to_message(view, message, transient):
     if not transient:
         view.window().focus_view(view)
     r = message.sublime_region(view)
-    view.run_command('rust_scroll_to_region', {'region': (r.a, r.a)})
+    view.run_command('rust_scroll_to_region', {'region': (r.end(), r.end())})
 
 
 def redraw_all_open_views(window):

--- a/tests/message-order/examples/warning1.rs
+++ b/tests/message-order/examples/warning1.rs
@@ -1,7 +1,7 @@
-/*WARN 1 "examples/warning1.rs:1" " --> examples/warning1.rs:1:69"*/fn unused_a() {
+fn unused_a() {
 
 }
 
-/*WARN 2 "examples/warning1.rs:5" " --> examples/warning1.rs:5:69"*/fn unused_b() {
+fn unused_b() {
 
 }

--- a/tests/message-order/examples/warning2.rs
+++ b/tests/message-order/examples/warning2.rs
@@ -79,6 +79,6 @@
 
 
 
-/*WARN 3 "examples/warning2.rs:82" "  --> examples/warning2.rs:82:72"*/fn unused_in_2() {
+fn unused_in_2() {
 
 }

--- a/tests/message-order/tests/test_all_levels.rs
+++ b/tests/message-order/tests/test_all_levels.rs
@@ -1,10 +1,10 @@
 trait Trait {}
 
 // This triggers a warning about lifetimes with help.
-fn f2</*WARN 2,1 "tests/test_all_levels.rs:4" " --> tests/test_all_levels.rs:4:85"*/'a: 'static>(_: &'a i32) {}
+fn f2<'a: 'static>(_: &'a i32) {}
 
 pub fn f() {
     let x = Box::new(0u32);
     // This is an error with a note and help.
-    let y: &dyn Trait = /*ERR 1,2 "tests/test_all_levels.rs:9" " --> tests/test_all_levels.rs:9:103"*/x;
+    let y: &dyn Trait = x;
 }

--- a/tests/message-order/tests/test_test_output.rs
+++ b/tests/message-order/tests/test_test_output.rs
@@ -6,29 +6,27 @@ fn passing() {
 
 #[test]
 fn basic_error1() {
-    // . is used for the column because Rust 1.24 changed the column indexing
-    // to be 1-based.
-    /*ERR 1 "tests/test_test_output.rs:11:4."*/assert!(false);
+    assert!(false);
 }
 
 #[test]
 fn basic_error2() {
-    /*ERR 2 "tests/test_test_output.rs:16:4."*/assert_eq!(1, 0);
+    assert_eq!(1, 0);
 }
 
 #[test]
 fn basic_error3() {
-    /*ERR 3 "tests/test_test_output.rs:21:4."*/assert_ne!(1, 1);
+    assert_ne!(1, 1);
 }
 
 #[test]
 fn custom_message() {
-    /*ERR 4 "tests/test_test_output.rs:26:4."*/assert!(false, "Custom message");
+    assert!(false, "Custom message");
 }
 
 #[test]
 fn manual_panic() {
-    /*ERR 5 "tests/test_test_output.rs:31:4."*/panic!("manual panic");
+    panic!("manual panic");
 }
 
 #[test]


### PR DESCRIPTION
This changes the next/prev commands to jump to the end of a message span instead
of the beginning. When using inline phantoms, jumping to the beginning can
be hard to see the message for a multi-line message.

I've flip-flopped over time which I like better. I've been using "end" for a
while now, and it seems to work better for me. If anyone objects, we can always
add a config setting.

This also changes how the test works, since the old test didn't handle this new
format very well.