### PR TITLE
fix: run test at cursor

### DIFF
--- a/cargo_build.py
+++ b/cargo_build.py
@@ -358,7 +358,7 @@ def _cargo_test_pt(what, pt, view):
                 'command': what,
                 'settings': {
                     'target': target,
-                    'extra_run_args': '--exact ' + test_fn_name
+                    'extra_run_args': test_fn_name
                 }
             })
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -39,7 +39,7 @@ class TestContext(TestBase):
         self._get_rust_thread().join()
         output = self._get_build_output(view.window())
         self.assertRegex(output,
-            r'\[Running: cargo test --test test_context --message-format=json -- --exact test1\]')
+            r'\[Running: cargo test --test test_context --message-format=json -- test1\]')
 
     def test_cargo_test_at_cursor(self):
         self._with_open_file('tests/multi-targets/tests/test_context.rs',
@@ -54,7 +54,7 @@ class TestContext(TestBase):
         self._get_rust_thread().join()
         output = self._get_build_output(view.window())
         self.assertRegex(output,
-            r'\[Running: cargo test --test test_context --message-format=json -- --exact expected_panic1\]')
+            r'\[Running: cargo test --test test_context --message-format=json -- expected_panic1\]')
 
     def test_cargo_test_current_file(self):
         self._with_open_file('tests/multi-targets/tests/test_context.rs',


### PR DESCRIPTION
the '--exact' option for cargo test doesn't exist (anymore). instead the test name should just come after the options