### PR TITLE
Syntax: Recover on bad enum syntax.

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -684,6 +684,9 @@ contexts:
     - match: '{{identifier}}'
       scope: entity.name.enum.rust
       set: enum-maybe-where
+    - match: '(?=\S)'
+      # Abort on invalid character.
+      pop: true
 
   enum-maybe-where:
     - meta_scope: meta.enum.rust
@@ -693,6 +696,9 @@ contexts:
     - match: '\{'
       scope: punctuation.definition.block.begin.rust
       set: enum-body
+    - match: '(?=\S)'
+      # Abort on invalid character.
+      pop: true
 
   enum-body:
     - meta_scope: meta.enum.rust


### PR DESCRIPTION
Break out of highlighting an enum definition when there is invalid syntax. This often happens with things like serde's `forward_to_deserialize_any`, it would get confused for many lines following.

```rust
    serde::forward_to_deserialize_any! {
        f32 f64 char str bytes
        byte_buf unit unit_struct
        enum identifier ignored_any newtype_struct
    }
```
