### PR TITLE
Fix type scoping in various circumstances

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -513,6 +513,7 @@ contexts:
       scope: meta.path.rust
     - match: '::(?={{identifier}})'
       scope: meta.path.rust
+    - include: basic-identifiers
     - match: '(?=<)'
       push: generic-angles
     - match: '\('


### PR DESCRIPTION
This properly assigns `storage.type.source.rust` to type signatures in method parameters (see `syntax-test-functions.rs` lines 30, 81, 88, 94, 101, etc.) and possibly other places.