### PR TITLE
Fix scoping for qualified function names

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -1306,6 +1306,8 @@ contexts:
         - include: no-path-identifiers
         - match: '::'
           set: no-type-names
+    - match: '\b[[:lower:]_][[:lower:][:digit:]_]*(?=\()'
+      scope: support.function.rust
     - match: '::(?={{identifier}})'
       scope: meta.path.rust
       push: no-type-names


### PR DESCRIPTION
This correctly assigns support.function.rust scope to qualified function names (e.g. `my_function` in `my_module::my_function(arg1, arg2)`). It might break something else, although a quick glance through the test files suggests it's fine.