### PR TITLE
Fix type of file_extensions property in Cargo syntax YAML

### DIFF
--- a/Cargo.sublime-syntax
+++ b/Cargo.sublime-syntax
@@ -2,7 +2,8 @@
 ---
 # http://www.sublimetext.com/docs/3/syntax.html
 name: Cargo Build Results
-file_extensions: rs
+file_extensions:
+  - rs
 scope: source.build_results
 
 variables:


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-enhanced/issues/427. I had to spend an hour debugging which of my many packages was breaking the [AutoSetSyntax](https://packagecontrol.io/packages/AutoSetSyntax) package, and this one came out as the culprit.

Thanks for discovering the fix, @BlackDex! This line now matches the one in [RustEnhanced.sublime-syntax](https://github.com/rust-lang/rust-enhanced/blob/master/RustEnhanced.sublime-syntax#L6)