### PR TITLE
Some improvements around message display.

### DIFF
--- a/rust/messages.py
+++ b/rust/messages.py
@@ -968,7 +968,9 @@ def _collect_rust_messages(window, base_path, info, target_path,
                     imsg.startswith('cannot continue') or
                     imsg.startswith('Some errors occurred') or
                     imsg.startswith('Some errors have detailed') or
-                    imsg.startswith('For more information about')):
+                    imsg.startswith('For more information about') or
+                    imsg.endswith('warning emitted') or
+                    imsg.endswith('warnings emitted')):
                 if target_path:
                     # Display at the bottom of the root path (like main.rs)
                     # for lack of a better place to put it.

--- a/rust/themes.py
+++ b/rust/themes.py
@@ -125,7 +125,7 @@ class ClearTheme(Theme):
         if isinstance(batch, PrimaryBatch):
             for url, path in batch.child_links:
                 msgs.append(self.LINK_TMPL.format(
-                    url=url, text='See Also:', path=path))
+                    url=url, text=see_also(url), path=path))
         else:
             if batch.back_link:
                 msgs.append(self.LINK_TMPL.format(
@@ -274,7 +274,7 @@ class SolidTheme(Theme):
             for url, path in batch.child_links:
                 links.append(
                     self.LINK_TMPL.format(
-                        url=url, text='See Also:', path=path))
+                        url=url, text=see_also(url), path=path))
             text = batch.primary_message.escaped_text(view, '&nbsp;' + icon('none'))
             if not text and not children:
                 return None
@@ -327,8 +327,8 @@ class TestTheme(Theme):
             messages.append(fake)
 
         if isinstance(batch, PrimaryBatch):
-            for link in batch.child_links:
-                add_fake(batch.primary_message, 'See Also: ' + link[1])
+            for url, path in batch.child_links:
+                add_fake(batch.primary_message, see_also(url) + ' ' + path)
         else:
             if batch.back_link:
                 add_fake(batch.first(), 'See Primary: ' + batch.back_link[1])
@@ -340,3 +340,10 @@ THEMES = {
     'solid': SolidTheme(),
     'test': TestTheme(),
 }
+
+def see_also(path):
+    print(path)
+    if path.endswith(':external'):
+        return 'See Also (external):'
+    else:
+        return 'See Also:'

--- a/tests/error-tests/tests/E0005.rs
+++ b/tests/error-tests/tests/E0005.rs
@@ -15,7 +15,7 @@ fn main() {
 //      ^^^^^^^ERR pattern `None` not covered
 //      ^^^^^^^ERR refutable pattern in local binding
 //      ^^^^^^^MSG(>=1.39.0-beta,<1.44.0-beta) See Also: ↑:1
-//      ^^^^^^^MSG(>=1.44.0-beta) See Also: ↓
+//      ^^^^^^^MSG(>=1.44.0-beta) See Also (external): option.rs:
 //      ^^^^^^^NOTE(>=1.40.0-beta) `let` bindings require
 //      ^^^^^^^NOTE(>=1.40.0-beta) for more information
 //      ^^^^^^^NOTE(>=1.44.0-beta) the matched value
@@ -25,6 +25,3 @@ fn main() {
 // Bug: https://github.com/rust-lang/rust/issues/64769
 // start-msg: ERR(>=1.39.0-beta,<1.44.0-beta) not covered
 // start-msg: MSG(>=1.39.0-beta,<1.44.0-beta) See Primary: ↓:14
-// end-msg: ERR(>=1.44.0-beta) Errors occurred in macro
-// end-msg: ERR(>=1.44.0-beta) not covered
-// end-msg: MSG(>=1.44.0-beta) See Primary: ↑:14

--- a/tests/error-tests/tests/impl-generic-mismatch.rs
+++ b/tests/error-tests/tests/impl-generic-mismatch.rs
@@ -59,8 +59,8 @@ impl Hash for X {
 //                              ^^^^^^^^^^^ERR method `hash` has incompatible signature
 //                              ^^^^^^^^^^^ERR(>=1.28.0-beta) expected generic parameter
 //                              ^^^^^^^^^^^ERR(<1.28.0-beta) annotation in impl
-//                              ^^^^^^^^^^^MSG(>=1.32.0) See Also: ↓
+//                              ^^^^^^^^^^^ERR(>=1.32.0,<1.44.0-beta) Errors occurred in
+//                              ^^^^^^^^^^^ERR(>=1.32.0,<1.44.0-beta) Macro text:
+//                              ^^^^^^^^^^^ERR(>=1.32.0,<1.44.0-beta) method `hash` has incompatible
+//                              ^^^^^^^^^^^MSG(>=1.44.0-beta) See Also (external): mod.rs:
 }
-// end-msg: ERR(>=1.32.0) Errors occurred in macro
-// end-msg: ERR(>=1.32.0) declaration in trait here
-// end-msg: MSG(>=1.32.0) See Primary: ↑:58


### PR DESCRIPTION
* Don't show the new warnings count.
* Treat errors in macros outside of the workspace with a special "external" tag, so the user knows that this is linked to something not in their package.