### PR TITLE
Auto-pair single quotes on selections

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -3,6 +3,14 @@
     { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'"}, "context":
         [{ "key": "selector", "operator": "equal", "operand": "source.rust" }]
     },
+    // auto-pair single quotes on selections.
+    { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'${0:$SELECTION}'"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.rust" },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
+        ]
+    },
     // ' in b'c' will skip past the end quote.
     { "keys": ["'"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
         [


### PR DESCRIPTION
This "re-adds" the ability to auto-pair single quotes when you have some text selected.

Sometimes I forget to quote the letter and on C++ code I generally just press `Shift+Left` followed by `'` to quote the char, but on Rust Enhanced this does not work. I know I can backspace and press `'` followed by the char, but my muscle memory has the former.

I understand the idea that it should not auto-pair because it's used as the lifetime label and that's why this only adds the ability when the text is selected.