### PR TITLE
Syntax: Switch support.function to variable.function

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -215,7 +215,7 @@ contexts:
       push: after-operator
 
     - match: '\b[[:lower:]_][[:lower:][:digit:]_]*(?=\()'
-      scope: support.function.rust
+      scope: variable.function.rust
 
     - match: '{{identifier}}'
 

--- a/tests/syntax-rust/syntax_test_control_flow.rs
+++ b/tests/syntax-rust/syntax_test_control_flow.rs
@@ -93,6 +93,6 @@ while let BasicStruct(k) = j {
 // <- meta.block punctuation.section.block.end
 
 continue_running();
-//^^^^^^^^^^^^^^ support.function
+//^^^^^^^^^^^^^^ variable.function
 break_things();
-//^^^^^^^^^^ support.function
+//^^^^^^^^^^ variable.function

--- a/tests/syntax-rust/syntax_test_enum.rs
+++ b/tests/syntax-rust/syntax_test_enum.rs
@@ -29,7 +29,7 @@ let w = Message::WriteString("Some string".to_string());
 //               ^^^^^^^^^^^ storage.type.source
 //                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
 //                           ^^^^^^^^^^^^^ string.quoted.double
-//                                         ^^^^^^^^^ support.function
+//                                         ^^^^^^^^^ variable.function
 let m = Message::Move { x: 50, y: 200 };
 //                    ^^^^^^^^^^^^^^^^^ meta.block
 //                         ^^ constant.numeric.integer.decimal

--- a/tests/syntax-rust/syntax_test_generics.rs
+++ b/tests/syntax-rust/syntax_test_generics.rs
@@ -242,7 +242,7 @@ fn collect_vec() {
 //                                   ^^ constant.numeric.integer.decimal
 //                                     ^ punctuation.section.group.end
 //                                      ^ punctuation.accessor.dot
-//                                       ^^^^^^^^^ support.function
+//                                       ^^^^^^^^^ variable.function
 //                                                ^^ punctuation.section.group
 //                                                  ^ punctuation.accessor.dot
 //                                                          ^^ punctuation.accessor
@@ -413,7 +413,7 @@ fn function<const N: u16>() {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.block meta.generic
 //            ^ punctuation.definition.generic.begin
 //                  ^^^^^^^^^^^^^^^^^^ meta.block
-//                    ^^^ support.function
+//                    ^^^ variable.function
 //                       ^ meta.group punctuation.section.group.begin
 //                          ^ keyword.operator.comparison
 //                             ^ punctuation.section.group.end

--- a/tests/syntax-rust/syntax_test_macros.rs
+++ b/tests/syntax-rust/syntax_test_macros.rs
@@ -84,7 +84,7 @@ my_var = format!("Hello {name}, how are you?",
         write!(get_writer(), "{}", "{}")
 //      ^^^^^^ support.macro
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
-//             ^^^^^^^^^^ support.function
+//             ^^^^^^^^^^ variable.function
 //                           ^^^^ string.quoted.double
 //                            ^^ constant.other.placeholder
 //                                 ^^^^ string.quoted.double

--- a/tests/syntax-rust/syntax_test_match.rs
+++ b/tests/syntax-rust/syntax_test_match.rs
@@ -40,7 +40,7 @@ match n {
 // Binding
 match my_func() {
 // ^^ keyword.control
-//    ^^^^^^^ support.function
+//    ^^^^^^^ variable.function
 //              ^ meta.block punctuation.section.block.begin
     0 => println!("None"),
 //  ^ constant.numeric.integer.decimal


### PR DESCRIPTION
support.function is intended only for functions that are provided by the
standard library. Rust doesn't really have very many free functions
(`drop` is about the only one in the prelude). variable.function is
supposed to be used for function calls.