### PR TITLE
Fix tests for macos split debuginfo.

### DIFF
--- a/tests/test_cargo_build.py
+++ b/tests/test_cargo_build.py
@@ -117,6 +117,7 @@ class TestCargoBuild(TestBase):
                 os.path.isfile(os.path.join(debug, x)) and
                 not x.startswith('.') and
                 not x.endswith('.d') and
+                not x.endswith('.o') and
                 not x.endswith('.pdb')]
             files.sort()
             # Remove any option (None) entries.


### PR DESCRIPTION
1.53 has switched macos to split debuginfo by default. The test that validates the file outputs needs to take this into account.