### PR TITLE
Add pat_param macro fragment specifier.

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -956,7 +956,7 @@ contexts:
           pop: true
         - include: macro-matchers
 
-    - match: '(\$\s*{{identifier}})\s*(:)\s*(ident|path|expr|ty|pat|stmt|block|item|meta|tt|lifetime|vis|literal)'
+    - match: '(\$\s*{{identifier}})\s*(:)\s*(ident|path|expr|ty|pat_param|pat|stmt|block|item|meta|tt|lifetime|vis|literal)'
       captures:
         1: variable.parameter.rust
         2: punctuation.separator.rust

--- a/tests/syntax-rust/syntax_test_macros.rs
+++ b/tests/syntax-rust/syntax_test_macros.rs
@@ -334,6 +334,9 @@ macro_rules! designators {
      $p:pat,
 //   ^^ variable.parameter
 //      ^^^ storage.type
+     $pp:pat_param,
+//   ^^^ variable.parameter
+//       ^^^^^^^^^ storage.type
      $e:expr,
 //   ^^ variable.parameter
 //      ^^^^ storage.type


### PR DESCRIPTION
pat_param was added in 1.53 via https://github.com/rust-lang/rust/pull/83386
