### PR TITLE
Fix replacement link on Sublime Text 4.

### DIFF
--- a/rust/messages.py
+++ b/rust/messages.py
@@ -146,13 +146,13 @@ class Message:
         html_suggestion = html_suggestion\
             .replace(' ', '&nbsp;')\
             .replace('\n', '<br>\n')
-        return replacement_template % (
-            urllib.parse.urlencode({
-                'id': self.id,
-                'replacement': self.suggested_replacement,
-            }),
-            html_suggestion,
-        )
+        url_param = urllib.parse.urlencode({
+            'id': self.id,
+            'replacement': self.suggested_replacement,
+        })
+        if int(sublime.version()) > 4000:
+            url_param = url_param.replace('&', '&amp;')
+        return replacement_template % (url_param, html_suggestion)
 
     def suggestion_count(self):
         """Number of suggestions in this message.


### PR DESCRIPTION
ST4 now requires HTML attribute values to be properly escaped (`&<>`). This is version-gated since ST3 doesn't unescape the value when sending it to the click handler. 

Fixes #443