### PR TITLE
README: fix image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a replacement for the built-in "Rust" package and provides several exten
 * Automatic checking every time you save a file.
 * Custom highlighting for Cargo output.
 
-<img src="docs/img/running_tests.gif?raw=true" alt="Running Tests with Rust Enhanced" width=430 style="margin-right:10px"> <img src="docs/img/showing_errors.gif?raw=true" alt="Highlighting errors and warnings with Rust Enhanced" width=430>
+<img src="docs/src/images/running_tests.gif?raw=true" alt="Running Tests with Rust Enhanced" width=430 style="margin-right:10px"> <img src="docs/src/images/showing_errors.gif?raw=true" alt="Highlighting errors and warnings with Rust Enhanced" width=430>
 
 ## Installation and Usage
 


### PR DESCRIPTION
#468 switched documentation methods, and that changed the path of the links in the repo. The README still referenced the old paths, so those images have been broken since that PR was merged. This PR switches those links to the new paths.