### PR TITLE
Switch unittesting to master.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   PACKAGE: "Rust Enhanced"
+  UNITTESTING_TAG: "master"
 
 jobs:
   linux:


### PR DESCRIPTION
This is to pick up https://github.com/SublimeText/UnitTesting/pull/201 which hasn't been tagged, yet.  It might also help to get early warning in case new changes cause issues.