### PR TITLE
prevent autocomplete inside comments

### DIFF
--- a/RustEnhanced.sublime-settings
+++ b/RustEnhanced.sublime-settings
@@ -86,7 +86,7 @@
     [
         {
             "characters": ".:",
-            "selector": "source.rust"
+            "selector": "source.rust - comment"
         }
     ]
 }


### PR DESCRIPTION
This prevents characters like `.` from triggering the autocomplete comment when the user types a `.` inside of a comment.

docs: https://www.sublimetext.com/docs/completions.html