### PR TITLE
Add a command to view the rendered build results

### DIFF
--- a/RustEnhanced.sublime-commands
+++ b/RustEnhanced.sublime-commands
@@ -57,6 +57,10 @@
         "command": "rust_open_log"
     },
     {
+        "caption": "Rust: Open Last Build Output As View",
+        "command": "rust_show_build_output"
+    },
+    {
         "caption": "Rust: Popup Message At Cursor",
         "command": "rust_message_popup"
     }

--- a/cargo_build.py
+++ b/cargo_build.py
@@ -243,7 +243,10 @@ class MessagesViewEventListener(sublime_plugin.ViewEventListener):
 class NextPrevBase(sublime_plugin.WindowCommand):
 
     def _has_inline(self):
-        return self.window.id() in messages.WINDOW_MESSAGES
+        try:
+            return messages.WINDOW_MESSAGES[self.window.id()]['has_inline']
+        except KeyError:
+            return False
 
 
 class RustNextMessageCommand(NextPrevBase):
@@ -519,6 +522,22 @@ class RustMessageStatus(sublime_plugin.ViewEventListener):
         else:
             view = self.view
         messages.update_status(view)
+
+
+class RustShowBuildOutput(sublime_plugin.WindowCommand):
+
+    """Opens a view with the rustc-rendered compiler output."""
+
+    def run(self):
+        view = self.window.new_file()
+        view.set_scratch(True)
+        view.set_name('Rust Enhanced Build Output')
+        view.assign_syntax('Cargo.sublime-syntax')
+        win_info = messages.get_or_init_window_info(self.window)
+        output = win_info['rendered']
+        if output == '':
+            output = "No output available for this window."
+        view.run_command('append', {'characters': output})
 
 
 class RustEventListener(sublime_plugin.EventListener):

--- a/rust/messages.py
+++ b/rust/messages.py
@@ -21,11 +21,15 @@ from .levels import *
 # Value is a dictionary: {
 #     'paths': {path: [MessageBatch, ...]},
 #     'batch_index': (path_idx, message_idx),
-#     'hidden': bool
+#     'hidden': bool,
+#     'rendered': string,
+#     'has_inline': False,
 # }
 # `paths` is an OrderedDict to handle next/prev message.
 # `path` is the absolute path to the file.
 # `hidden` indicates that all messages have been dismissed.
+# `rendered` is the rustc-rendered output
+# 'has_inline' is a boolean indicating if inline messages were added
 WINDOW_MESSAGES = {}
 
 
@@ -302,9 +306,8 @@ def _draw_region_highlights(view, batch):
 
 def batches_at_point(view, point, hover_zone):
     """Return a list of message batches at the given point."""
-    try:
-        winfo = WINDOW_MESSAGES[view.window().id()]
-    except KeyError:
+    winfo = get_window_info_for_view(view)
+    if winfo is None:
         return
     if winfo['hidden']:
         return
@@ -615,9 +618,8 @@ def redraw_all_open_views(window):
 
 def show_messages_for_view(view):
     """Adds all phantoms and region outlines for a view."""
-    try:
-        winfo = WINDOW_MESSAGES[view.window().id()]
-    except KeyError:
+    winfo = get_window_info_for_view(view)
+    if winfo is None:
         return
     if winfo['hidden']:
         return
@@ -628,9 +630,8 @@ def show_messages_for_view(view):
 
 
 def draw_regions_if_missing(view):
-    try:
-        winfo = WINDOW_MESSAGES[view.window().id()]
-    except KeyError:
+    winfo = get_window_info_for_view(view)
+    if winfo is None:
         return
     if winfo['hidden']:
         return
@@ -1180,16 +1181,9 @@ def _save_batches(window, batches, msg_cb):
     - Displays phantoms if a view is already open.
     - Calls `msg_cb` for each individual message.
     """
-    wid = window.id()
-    try:
-        path_to_batches = WINDOW_MESSAGES[wid]['paths']
-    except KeyError:
-        path_to_batches = collections.OrderedDict()
-        WINDOW_MESSAGES[wid] = {
-            'paths': path_to_batches,
-            'batch_index': (-1, -1),
-            'hidden': False,
-        }
+    win_info = get_or_init_window_info(window)
+    win_info['has_inline'] = True
+    path_to_batches = win_info['paths']
 
     for batch in batches:
         path_batches = path_to_batches.setdefault(batch.path(), [])
@@ -1198,7 +1192,7 @@ def _save_batches(window, batches, msg_cb):
         path_batches.append(batch)
         for i, msg in enumerate(batch):
             msg.region_key = 'rust-%i' % (num + i,)
-        if not WINDOW_MESSAGES[wid]['hidden']:
+        if not win_info['hidden']:
             views = util.open_views_for_file(window, batch.path())
             if views:
                 # Phantoms seem to be attached to the buffer.
@@ -1208,3 +1202,32 @@ def _save_batches(window, batches, msg_cb):
             if msg_cb:
                 for msg in batch:
                     msg_cb(msg)
+
+
+def get_or_init_window_info(window):
+    """Returns the window info for the given window, creating it if it hasn't been set."""
+    wid = window.id()
+    try:
+        return WINDOW_MESSAGES[wid]
+    except KeyError:
+        win_info = {
+            'paths': collections.OrderedDict(),
+            'batch_index': (-1, -1),
+            'hidden': False,
+            'rendered': '',
+            'has_inline': False,
+        }
+        WINDOW_MESSAGES[wid] = win_info
+        return win_info
+
+
+def get_window_info_for_view(view):
+    """Returns the window info for the given view, or None if not available."""
+    window = view.window()
+    if window is None:
+        # I'm not entire sure why this happens sometimes.
+        return None
+    try:
+        return WINDOW_MESSAGES[window.id()]
+    except KeyError:
+        return None


### PR DESCRIPTION
The `Rust: Open Last Build Output As View` command will open a view with the build results as rendered by rustc. 
This probably still needs some work, such as making it easier to access.