### PR TITLE
Fix "in this macro invocation" for desugarings.

### DIFF
--- a/rust/messages.py
+++ b/rust/messages.py
@@ -1065,9 +1065,13 @@ def _collect_rust_messages(window, base_path, info, target_path,
 
         # Add a message for macro invocation site if available in the local
         # crate.
+        #
+        # `macro_decl_name` can be a variety of things, like fn-like macro,
+        # attribute, derive, "desugaring of", etc. We can generally only
+        # handle macro_rules macros.
         if span['expansion'] and \
                 not _is_external(window, span['file_name']) and \
-                not span['expansion']['macro_decl_name'].startswith('#['):
+                span['expansion']['macro_decl_name'].endswith('!'):
             invoke_span, expansion = find_span_r(span)
             # TODO: rustc now emits this in its text output in some cases.
             # Consider trying to avoid the duplicate note.


### PR DESCRIPTION
The "in this macro invocation" doesn't handle desugarings and attributes. This changes the check for that to only check for bang macros. This probably could be done better, but should work for now.

Fixes #517