### PR TITLE
CI: use actions/deploy-pages instead of pushing to gh-pages branches 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: bash ci/install-rust.sh ${{ matrix.rust }}
-      # Temporary workaround until Package Control 4 works
-      # https://github.com/wbond/package_control/issues/1612
-      - name: Fix macOS OpenSSL
-        if: matrix.os == 'macos-latest'
-        run: brew unlink openssl
       - uses: SublimeText/UnitTesting/actions/setup@v1
         with:
           package-name: Rust Enhanced

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             rust: nightly
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - run: bash ci/install-rust.sh ${{ matrix.rust }}
       - uses: SublimeText/UnitTesting/actions/setup@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,10 @@ on:
       - master
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Install mdbook
@@ -16,18 +16,20 @@ jobs:
         mkdir mdbook
         curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.11/mdbook-v0.4.11-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
-    - name: Deploy docs
-      run: |
-        cd docs
-        mdbook build
-        git worktree add gh-pages gh-pages
-        git config user.name "Deploy from CI"
-        git config user.email ""
-        cd gh-pages
-        # Delete the ref to avoid keeping history.
-        git update-ref -d refs/heads/gh-pages
-        rm -rf *
-        mv ../book/* .
-        git add .
-        git commit -m "Deploy $GITHUB_SHA to gh-pages"
-        git push --force
+    - name: Build book
+      run: cd docs && mdbook build
+    - name: Upload page artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: docs/book
+        retention-days: 1
+
+  deploy:
+    permissions:
+      pages: write
+      id-token: write
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Before merging this, you need to enable deploying pages by Actions in [Settings](https://github.com/rust-lang/rust-enhanced/settings/pages).

![Screenshot from 2024-05-20 03-55-58](https://github.com/rust-lang/rust-enhanced/assets/15225902/d674bad8-5ee7-4767-baf4-68a7da731fd4)