### PR TITLE
Add support for `use` bounds

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -364,13 +364,6 @@ contexts:
       scope: support.type.rust
 
   return-type:
-    - match: '\bimpl\b'
-      scope: storage.type.impl.rust
-      push:
-        - include: comments
-        - include: impl-generic
-        - match: '(?=\S)'
-          pop: true
     - match: '->'
       scope: punctuation.separator.rust
       push:
@@ -578,6 +571,31 @@ contexts:
     - match: '[-+%/*]'
       scope: keyword.operator.arithmetic.rust
 
+  impl-trait:
+    - match: '\bimpl\b'
+      scope: storage.type.impl.rust
+      push:
+        - match: '\buse\b'
+          scope: keyword.other.rust
+          push:
+            - match: '<'
+              scope: punctuation.definition.generic.begin.rust
+              set:
+                - match: '>'
+                  scope: punctuation.definition.generic.end.rust
+                  pop: true
+                - include: lifetime
+                - match: ','
+                  scope: punctuation.separator.rust
+                - match: \b(Self)\b
+                  scope: keyword.other.rust
+                - match: '{{identifier}}'
+                - match: '(?=\S)'
+                  pop: true
+        - include: type-any-identifier
+        - match: '(?=\S)'
+          pop: true
+
   type-any-identifier:
     - include: comments
     - include: support-type
@@ -604,6 +622,7 @@ contexts:
               pop: true
         - include: type-any-identifier
     - include: lifetime
+    - include: impl-trait
     - match: '\b([[:upper:]]|_*[[:upper:]][[:alnum:]_]*[[:lower:]][[:alnum:]_]*)\b(::)'
       scope: meta.path.rust storage.type.rust
       captures:

--- a/tests/syntax-rust/syntax_test_generics.rs
+++ b/tests/syntax-rust/syntax_test_generics.rs
@@ -461,19 +461,20 @@ fn impl_trait_return_use_bound<'a>() -> impl for<'b> Trait1<Item = impl Trait2<'
 //                                                                             ^^ storage.modifier.lifetime
 //                                                                               ^ punctuation.definition.generic.end
 //                                                                                 ^ keyword.operator
-//                                                                                   ^^^^^^^ meta.generic meta.generic
+//                                                                                   ^^^^^^^^ meta.generic
+//                                                                                   ^^^ keyword.other
 //                                                                                      ^ punctuation.definition.generic.begin
 //                                                                                       ^^ storage.modifier.lifetime
-//                                                                                         ^ punctuation.definition.generic.end
-//                                                                                          ^ punctuation.definition.generic.end
+//                                                                                         ^^ punctuation.definition.generic.end
 
 fn impl_trait_use<'a, foo>() -> impl Trait1 + use<'a, Self, foo> {}
 //                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
-//                                            ^^^^^^^^^^^^^^^^^^ meta.generic
+//                                          ^ keyword.operator
+//                                            ^^^ keyword.other
 //                                               ^ punctuation.definition.generic.begin
 //                                                ^^ storage.modifier.lifetime
 //                                                  ^ punctuation.separator
-//                                                    ^^^^ storage.type
+//                                                    ^^^^ keyword.other
 //                                                        ^ punctuation.separator
 //                                                             ^ punctuation.definition.generic.end
 

--- a/tests/syntax-rust/syntax_test_generics.rs
+++ b/tests/syntax-rust/syntax_test_generics.rs
@@ -439,8 +439,94 @@ fn function<const N: u16>() {
 //              ^^^ storage.type.numeric
     let b: Byte<b'a'>;
 //             ^^^^^^ meta.function meta.block meta.generic
-//              ^^^^ string.quoted.single.rust
+//              ^^^^ string.quoted.single
 //              ^ storage.type.string
 //               ^ punctuation.definition.string.begin
 //                 ^ punctuation.definition.string.end
 }
+
+fn impl_trait_return_use_bound<'a>() -> impl for<'b> Trait1<Item = impl Trait2<'a> + use<'a>> {}
+//                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
+//                                   ^^ punctuation.separator
+//                                      ^^^^ storage.type.impl
+//                                           ^^^ keyword.other
+//                                              ^ meta.generic punctuation.definition.generic.begin
+//                                                 ^ meta.generic punctuation.definition.generic.end
+//                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic
+//                                                         ^ meta.generic punctuation.definition.generic.begin
+//                                                               ^ meta.generic keyword.operator
+//                                                                 ^^^^ meta.generic storage.type.impl
+//                                                                      ^^^^^^^^^^ meta.generic meta.generic
+//                                                                            ^ punctuation.definition.generic.begin
+//                                                                             ^^ storage.modifier.lifetime
+//                                                                               ^ punctuation.definition.generic.end
+//                                                                                 ^ keyword.operator
+//                                                                                   ^^^^^^^ meta.generic meta.generic
+//                                                                                      ^ punctuation.definition.generic.begin
+//                                                                                       ^^ storage.modifier.lifetime
+//                                                                                         ^ punctuation.definition.generic.end
+//                                                                                          ^ punctuation.definition.generic.end
+
+fn impl_trait_use<'a, foo>() -> impl Trait1 + use<'a, Self, foo> {}
+//                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
+//                                            ^^^^^^^^^^^^^^^^^^ meta.generic
+//                                               ^ punctuation.definition.generic.begin
+//                                                ^^ storage.modifier.lifetime
+//                                                  ^ punctuation.separator
+//                                                    ^^^^ storage.type
+//                                                        ^ punctuation.separator
+//                                                             ^ punctuation.definition.generic.end
+
+fn impl_trait_return1<'a, 'b>() -> impl Trait<&'a u8, Ty = impl Sized + 'b> {}
+//                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
+//                              ^^ punctuation.separator
+//                                 ^^^^ storage.type.impl
+//                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.generic
+//                                           ^ punctuation.definition.generic.begin
+//                                            ^ keyword.operator
+//                                             ^^ storage.modifier.lifetime
+//                                                ^^ storage.type
+//                                                  ^ punctuation.separator
+//                                                       ^ keyword.operator
+//                                                         ^^^^ storage.type.impl
+//                                                              ^^^^^ support.type
+//                                                                    ^ keyword.operator
+//                                                                      ^^ storage.modifier.lifetime
+//                                                                        ^ punctuation.definition.generic.end
+fn impl_trait_return2() -> impl Debug + 'a {}
+//                      ^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
+//                         ^^^^ storage.type.impl
+//                                    ^ keyword.operator
+//                                      ^^ storage.modifier.lifetime
+
+fn impl_trait_param(x: impl FnOnce(&[u8]) -> &[u8])  {}
+//                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.parameters
+//                     ^^^^ storage.type.impl
+//                          ^^^^^^ support.type
+//                                ^ meta.group punctuation.section.group.begin
+//                                 ^ meta.group keyword.operator
+//                                  ^ meta.group punctuation.section.group.begin
+//                                   ^^ meta.group storage.type
+//                                     ^^ meta.group punctuation.section.group.end
+//                                        ^^^^^^^^ meta.function meta.function.parameters meta.function.return-type
+//                                        ^^ punctuation.separator
+//                                           ^ meta.function.parameters keyword.operator
+//                                            ^ meta.function.parameters punctuation.section.group.begin
+//                                             ^^ meta.function.parameters storage.type
+//                                               ^ meta.function.parameters punctuation.section.group.end
+
+
+fn impl_trait_with_plus() -> impl Iterator<Item = hir::GenericParam<'hir>> + Captures<'a> + Captures<'s> {}
+//                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function meta.function.return-type
+//                           ^^^^ storage.type.impl
+//                                ^^^^^^^^ support.type
+//                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.generic
+//                                              ^ keyword.operator
+//                                                                  ^^^^ storage.modifier.lifetime
+//                                                                         ^ keyword.operator
+//                                                                           ^^^^^^^^^^^^ meta.generic
+//                                                                                    ^^ storage.modifier.lifetime
+//                                                                                        ^ keyword.operator
+//                                                                                          ^^^^^^^^^^^^ meta.generic
+//                                                                                                   ^^ storage.modifier.lifetime
+


### PR DESCRIPTION
This adds support for `use` bounds (https://github.com/rust-lang/rust/issues/123432).

I'm not really sure these are the best scope names, but they should be ok to start.

I didn't fully understand the original return-type `impl` match, since `-> impl<..>` isn't real syntax. This new context should replace it.