### PR TITLE
Remove cargo-script

### DIFF
--- a/cargo_build.py
+++ b/cargo_build.py
@@ -38,8 +38,8 @@ class CargoExecCommand(sublime_plugin.WindowCommand):
     settings = None
     # Directory where to run the command.
     working_dir = None
-    # Path used for the settings key.  This is typically `working_dir` except
-    # for `cargo script`, in which case it is the path to the .rs source file.
+    # Path used for the settings key. This is typically `working_dir`
+    # (previously was used for script paths, now unused).
     settings_path = None
 
     def run(self, command=None, command_info=None, settings=None):
@@ -135,7 +135,7 @@ class CargoExecCommand(sublime_plugin.WindowCommand):
             cmd.run(functools.partial(self._on_manifest_choice, on_done))
         else:
             # For now, assume you need a Rust file if not needing a manifest
-            # (for `cargo script`).
+            # (previously used for `cargo script`, now unused).
             view = self.window.active_view()
             if util.active_view_is_rust(view=view):
                 self.settings_path = view.file_name()

--- a/ci/install-rust.sh
+++ b/ci/install-rust.sh
@@ -26,7 +26,6 @@ rustup update --no-self-update $TOOLCHAIN
 rustup default $TOOLCHAIN
 rustup component add clippy
 rustup component add rust-src
-cargo install cargo-script
 rustup -V
 rustc -Vv
 cargo -V

--- a/docs/src/build/custom.md
+++ b/docs/src/build/custom.md
@@ -23,5 +23,5 @@ Setting Name | Default | Description
 `allows_json` |  False | If True, allows `--message-format=json` flag.
 `json_stop_pattern` | None | A regular expression matched against Cargo's output to detect when it should stop looking for JSON messages (used by `cargo run` to stop looking for JSON messages once compilation is finished).
 `requires_manifest` | True | If True, the command must be run in a directory with a `Cargo.toml` manifest.
-`requires_view_path` |  False | If True, then the active view must be a Rust source file, and the path to that file will be passed into Cargo (used mainly by `cargo script`).
+`requires_view_path` |  False | If True, then the active view must be a Rust source file, and the path to that file will be passed into Cargo (previously used by `cargo script`, now unused).
 `wants_run_args` |  False | If True, it will ask for extra args to pass to the executable (after the `--` flag separator).

--- a/docs/src/build/index.md
+++ b/docs/src/build/index.md
@@ -42,7 +42,6 @@ Bench | <code>cargo&nbsp;bench</code> | Runs benchmarks.
 Clean | <code>cargo&nbsp;clean</code> | Removes all built files.
 Document | <code>cargo&nbsp;doc</code> | Builds package documentation.
 Clippy | <code>cargo&nbsp;clippy</code> | Runs [Clippy](https://github.com/Manishearth/rust-clippy). Clippy must be installed, and currently requires the nightly toolchain.
-Script | <code>cargo&nbsp;script&nbsp;$path</code> | Runs [Cargo Script](https://github.com/DanielKeep/cargo-script). Cargo Script must be installed. This is an addon that allows you to run a Rust source file like a script (without a Cargo.toml manifest).
 
 You can add custom build variants, see [Custom Build Variants](custom.md) for more.
 

--- a/docs/src/build/settings.md
+++ b/docs/src/build/settings.md
@@ -38,8 +38,7 @@ Key | Description
 `"variants"` | Settings per build variant.
 `"defaults"` | Default settings used if not set per target or variant.
 
-Paths should be an absolute path to the directory of a Cargo package, or the
-path to a Rust source file (when used with `cargo script`).
+Paths should be an absolute path to the directory of a Cargo package.
 
 `"paths"` is an object of path keys mapping to an object with the keys:
 
@@ -107,7 +106,7 @@ Setting Name | Description
 `extra_run_args` | String of extra arguments passed to Cargo (after the `--` flags separator).
 `env` | Object of environment variables to add when running Cargo.
 `working_dir` | The directory where to run Cargo. If not specified, uses the value from `default_path`, otherwise attempts to detect from the active view, or displays a panel to choose a Cargo package.
-`script_path` | Path to a `.rs` script, used by `cargo script` if you want to hard-code a specific script to run.
+`script_path` | Path to a `.rs` script (previously used by `cargo script`, now unused).
 `no_default_features` | If True, sets the `--no-default-features` flag.
 
 The extra args settings support standard Sublime variable expansion (see [Build System Variables](https://www.sublimetext.com/docs/build_systems.html)).

--- a/rust/cargo_settings.py
+++ b/rust/cargo_settings.py
@@ -99,17 +99,6 @@ CARGO_COMMANDS = {
         'allows_features': True,
         'allows_json': True,
     },
-    'script': {
-        'name': 'Script',
-        'command': 'script',
-        'allows_target': False,
-        'allows_target_triple': False,
-        'allows_release': False,
-        'allows_features': False,
-        'allows_json': False,
-        'requires_view_path': True,
-        'requires_manifest': False,
-    },
 }
 
 
@@ -357,7 +346,7 @@ class CargoSettings(object):
         :param cmd_info: Dictionary from `CARGO_COMMANDS` with rules on how to
             construct the command.
         :param settings_path: The absolute path to the Cargo project root
-            directory or script.
+            directory.
         :param working_dir: The directory where Cargo is to be run (typically
             the project root).
         :keyword initial_settings: Initial settings to inject which override
@@ -425,7 +414,7 @@ class CargoSettings(object):
                     result.append('--features')
                     result.append(v)
 
-        # Add path from current active view (mainly for "cargo script").
+        # Add path from current active view (mainly for "cargo script", now unused).
         if cmd_info.get('requires_view_path', False):
             script_path = get_computed('script_path')
             if not script_path:

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,6 @@ You also need the following installed and in your PATH:
 - Rust, Cargo, and Rustup
 - `nightly` Rust toolchain.
 - Clippy (https://github.com/Manishearth/rust-clippy)
-- Cargo Script (https://github.com/DanielKeep/cargo-script)
 
 It also assumes you have not made any changes to the default RustEnhanced
 settings.

--- a/tests/test_cargo_build.py
+++ b/tests/test_cargo_build.py
@@ -385,17 +385,6 @@ class TestCargoBuild(TestBase):
         else:
             raise AssertionError('Failed to find %r' % pattern)
 
-    def test_script(self):
-        """Test "Script" variant."""
-        self._with_open_file('tests/multi-targets/mystery.rs',
-            self._test_script)
-
-    def _test_script(self, view):
-        window = view.window()
-        self._run_build_wait('script')
-        output = self._get_build_output(window)
-        self.assertRegex(output, '(?m)^Hello Mystery$')
-
     def test_features(self):
         """Test feature selection."""
         self._with_open_file('tests/multi-targets/src/bin/feats.rs',


### PR DESCRIPTION
It is no longer supported and doesn't build anymore.

Will possibly replace this in the future with cargo's native scripting ability.