### PR TITLE
Disable some tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches-ignore: [master]
   pull_request:
     branches: ['*']
-  schedule:
-    - cron: '20 6 * * *'
 
 jobs:
   tests:

--- a/tests/test_click_handler.py
+++ b/tests/test_click_handler.py
@@ -31,6 +31,7 @@ REPLACEMENT_TESTS = [
 
 class TestClickHandler(TestBase):
 
+    @unittest.skip("Test is too finicky to maintain")
     def test_accept_replacement(self):
         rustc_version = util.get_rustc_version(sublime.active_window(), plugin_path)
         for filename, version, before, after in REPLACEMENT_TESTS:

--- a/tests/test_message_order.py
+++ b/tests/test_message_order.py
@@ -78,6 +78,7 @@ class TestMessageOrder(TestBase):
                                                 'variant': 'test',
                                                 'package': pkg})
 
+    @unittest.skip("Test is too finicky to maintain")
     def test_message_order(self):
         """Test message order.
 

--- a/tests/test_syntax_check.py
+++ b/tests/test_syntax_check.py
@@ -17,6 +17,7 @@ class TestSyntaxCheck(TestBase):
         self.rustc_version = util.get_rustc_version(sublime.active_window(),
                                                     plugin_path)
 
+    @unittest.skip("Test is too finicky to maintain")
     def test_messages(self):
         """Test message generation.
 
@@ -145,6 +146,7 @@ class TestSyntaxCheck(TestBase):
             self._with_open_file(paths[0], self._test_messages,
                 setups=setups + extra_setups, extra_paths=paths[1:])
 
+    @unittest.skip("Test is too finicky to maintain")
     def test_clippy_messages(self):
         """Test clippy messages."""
         if self._skip_clippy():


### PR DESCRIPTION
These tests require too much effort to maintain because the compiler is constantly changing its output. In the past it has caught some issues with the compiler breaking some things, but in general it hasn't caught anything in a very long time. Perhaps a different approach would be to simulate the compiler's output with fixed JSON so that version differences wouldn't matter. For now, I'm disabling the tests since I won't be able to maintain these anymore.